### PR TITLE
Remove 'Why' section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,6 @@ fluxtty applies vim's modal philosophy to this problem. You have a persistent vi
 
 ---
 
-## Why
-
-Modern AI-assisted development looks different from traditional coding. You are no longer just in one editor. You have multiple `claude` sessions running in parallel, each working on a different part of the codebase. You have dev servers, test runners, database shells, and CI watchers all running at once. Your job is to supervise them — review outputs, redirect agents, intervene when things go wrong, and dispatch new instructions.
-
-The usual terminal workflow breaks down here. Alt-tabbing between windows is disorienting at scale. tmux panes get too small to be useful. The mouse is slow.
-
-fluxtty applies vim's modal philosophy to this problem. You have a persistent view of all your terminals, and a modal input bar that knows the difference between "I want to type into a shell" (`i`), "I want to talk to my workspace AI" (`a`), and "I want to navigate" (Normal mode with `hjkl`). One window. Keyboard-first. Designed for the way AI development actually works.
-
----
-
 ## What it is
 
 fluxtty is not a general-purpose terminal emulator. It is a workspace — designed specifically for developers running many shells simultaneously who need to navigate across them, dispatch commands, and observe output without constantly mousing around.


### PR DESCRIPTION
Removed the 'Why' section to streamline the README.

## Summary

- What does this change do?
- Why is it needed?

## Testing

- [ ] `npx tsc --noEmit`
- [ ] `npx vite build`
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml`
- [ ] Manual verification completed

## Checklist

- [ ] Scope is focused and reviewable
- [ ] Docs updated if behavior changed
- [ ] Screenshots added for UI changes
- [ ] No secrets or local-only config were committed
