### PR TITLE
Replace MP4 with Vimeo embed on GitHub Pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -168,12 +168,22 @@
     }
 
     .demo-video {
+      position: relative;
       width: 100%;
+      padding-bottom: 56.25%; /* 16:9 */
       border-radius: 12px;
       box-shadow: 0 32px 96px rgba(0,0,0,0.6);
       border: 1px solid #30363d;
-      display: block;
+      overflow: hidden;
       margin-bottom: 2rem;
+    }
+
+    .demo-video iframe {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      border: 0;
     }
 
     /* ── The Shift ── */
@@ -502,10 +512,11 @@
 <!-- Demo -->
 <div class="demo-wrap">
 
-  <video class="demo-video"
-    src="https://github.com/user-attachments/assets/6b87c695-d5bc-4aa5-8a6f-cbd2ad973b99"
-    autoplay loop muted playsinline controls>
-  </video>
+  <div class="demo-video">
+    <iframe src="https://player.vimeo.com/video/1177284500?autoplay=1&muted=1&loop=1&background=1"
+      allow="autoplay; fullscreen; picture-in-picture" allowfullscreen>
+    </iframe>
+  </div>
 
 
 <hr />


### PR DESCRIPTION
## Summary

- Replace unreliable user-attachments MP4 with Vimeo iframe player in GitHub Pages
- Add responsive 16:9 wrapper with matching border-radius and box-shadow styling
- README unchanged (user-attachments video works fine on github.com)

## Test plan
- [ ] Verify video plays on GitHub Pages