### PR TITLE
ci: auto-bump version files from tag before Tauri build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,20 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
+      - name: Bump version from tag
+        shell: bash
+        run: |
+          VERSION="${TAG_NAME#v}"
+          jq --arg v "$VERSION" '.version = $v' package.json > tmp.json && mv tmp.json package.json
+          jq --arg v "$VERSION" '.version = $v' src-tauri/tauri.conf.json > tmp.json && mv tmp.json src-tauri/tauri.conf.json
+          python3 -c "
+          import re
+          path = 'src-tauri/Cargo.toml'
+          content = open(path).read()
+          content = re.sub(r'^version = \".*?\"', 'version = \"$VERSION\"', content, count=1, flags=re.MULTILINE)
+          open(path, 'w').write(content)
+          "
+
       - name: Build and publish Tauri bundle
         uses: tauri-apps/tauri-action@v0.6.2
         env:


### PR DESCRIPTION
## Summary

- Adds a "Bump version from tag" step to the release workflow that runs before `tauri-action`
- Patches `package.json`, `src-tauri/tauri.conf.json`, and `src-tauri/Cargo.toml` with the version derived from the git tag
- Fixes the issue where artifact filenames were named after the hardcoded version in those files (e.g. `fluxtty_0.1.1_aarch64.dmg`) instead of the release tag (e.g. `fluxtty_0.1.3_aarch64.dmg`)

## Test plan

- [ ] Merge this PR
- [ ] Re-tag v0.1.3 to trigger a clean release build
- [ ] Verify artifacts are named `fluxtty_0.1.3_aarch64.dmg` and `fluxtty_0.1.3_x64.dmg`
- [ ] Verify `brew install --cask fluxtty` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)