### PR TITLE
feat: add compact workspace mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ All bindings are configurable in `config.yaml`.
 | `/` | Fuzzy pane search |
 | `r` | Rename pane |
 | `b` | Toggle sidebar |
-| `gg` / `G` | Scroll to top / bottom |
+| `gg` / `G` | Jump workspace to top / bottom |
 | `Ctrl+D` / `Ctrl+U` | Scroll half page |
 
 ### Global
@@ -228,4 +228,3 @@ The waterfall layout idea — terminals stacking vertically, each filling the vi
 ## License
 
 MIT
-

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -940,6 +940,7 @@ dependencies = [
  "dirs",
  "log",
  "notify",
+ "objc",
  "parking_lot",
  "portable-pty",
  "reqwest 0.12.28",
@@ -2058,6 +2059,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,6 +2308,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,3 +31,6 @@ uuid = { version = "1", features = ["v4"] }
 parking_lot = "0.12"
 crossbeam-channel = "0.5"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc = "0.2"

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -26,6 +26,7 @@ pub struct WindowConfig {
     pub padding: PaddingConfig,
     pub decorations: String,
     pub startup_mode: String,
+    pub compact_mode: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -148,6 +149,7 @@ pub struct WaterfallConfig {
     pub new_pane_focus: bool,
     pub note_width: u32,
     pub pane_min_width: u32,
+    pub show_note_button: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -195,6 +197,7 @@ impl Default for WindowConfig {
             padding: PaddingConfig { x: 8, y: 6 },
             decorations: "full".to_string(),
             startup_mode: "windowed".to_string(),
+            compact_mode: false,
         }
     }
 }
@@ -358,6 +361,7 @@ impl Default for WaterfallConfig {
             new_pane_focus: true,
             note_width: 280,
             pane_min_width: 150,
+            show_note_button: true,
         }
     }
 }

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -689,3 +689,41 @@ pub async fn workspace_snapshot_load(
         }
     }
 }
+
+
+// ── Window chrome ──────────────────────────────────────────────────────────────────────────────
+
+/// Show or hide the macOS traffic-light buttons without touching window
+/// decorations (which would remove rounded corners and shadow).
+/// On non-macOS platforms this is a no-op.
+// `sel_impl` from objc 0.2 emits an unexpected_cfgs warning about cargo-clippy.
+// It is harmless — suppress it for this function.
+#[allow(unexpected_cfgs)]
+#[tauri::command]
+pub async fn window_set_traffic_lights_hidden(
+    window: tauri::WebviewWindow,
+    hidden: bool,
+) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        use objc::{msg_send, sel, sel_impl};
+        use objc::runtime::Object;
+
+        // Cast to usize so the value is Send and can be moved into the closure.
+        let ns_win_ptr = window.ns_window().map_err(|e| e.to_string())? as usize;
+
+        window.run_on_main_thread(move || unsafe {
+            let ns_win = ns_win_ptr as *mut Object;
+            // NSWindowCloseButton = 0, NSWindowMiniaturizeButton = 1, NSWindowZoomButton = 2
+            for kind in [0i64, 1i64, 2i64] {
+                let btn: *mut Object = msg_send![ns_win, standardWindowButton: kind];
+                if !btn.is_null() {
+                    let _: () = msg_send![btn, setHidden: hidden as u8];
+                }
+            }
+        }).map_err(|e| e.to_string())?;
+    }
+    #[cfg(not(target_os = "macos"))]
+    let _ = (window, hidden);
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -128,6 +128,7 @@ pub fn run() {
             llm_complete,
             workspace_snapshot_save,
             workspace_snapshot_load,
+            window_set_traffic_lights_hidden,
         ])
         .run(tauri::generate_context!())
         .expect("error while running fluxtty");

--- a/src/app.ts
+++ b/src/app.ts
@@ -248,6 +248,9 @@ async function restoreSnapshot(snapshot: WorkspaceSnapshot, waterfallArea: Water
 
   let lastRowIndex = -1;
   let domRowIdx = -1;
+  // Collect notes keyed by domRowIdx — applied after all panes in the row are
+  // spawned so the note pane is always appended last (i.e. stays at far right).
+  const pendingNotes = new Map<number, string>();
 
   for (const snap of sorted) {
     const isNewRow = snap.row_index !== lastRowIndex;
@@ -273,16 +276,23 @@ async function restoreSnapshot(snapshot: WorkspaceSnapshot, waterfallArea: Water
     }
     await Promise.all(renames);
 
-    // Restore row note (stored only on the first pane per row).
+    // Queue row note (stored only on the first pane per row) for later so that
+    // all terminal panes in the row are in the DOM before the note pane is
+    // appended — keeping the note pinned at the far right.
     if (snap.pane_index === 0 && snap.note) {
-      const rowEls = waterfallArea.getRowsWithNotes();
-      const rowData = rowEls[domRowIdx];
-      if (rowData) waterfallArea.setRowNote(rowData.rowEl, snap.note);
+      pendingNotes.set(domRowIdx, snap.note);
     }
 
     if (snap.is_active) {
       await sessionManager.setActivePane(pane.paneId);
     }
+  }
+
+  // Apply row notes now that every pane has been spawned.
+  for (const [rowIdx, note] of pendingNotes) {
+    const rowEls = waterfallArea.getRowsWithNotes();
+    const rowData = rowEls[rowIdx];
+    if (rowData) waterfallArea.setRowNote(rowData.rowEl, note);
   }
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -112,6 +112,16 @@ export async function initApp(root: HTMLElement) {
     }
   });
 
+  // Compact mode: hide/show macOS traffic-light buttons via native NSWindow API.
+  // CSS cannot cover native controls; this uses objc FFI to setHidden on each button.
+  if (isMac) {
+    const applyTrafficLights = (compact: boolean) => {
+      invoke('window_set_traffic_lights_hidden', { hidden: compact }).catch(() => {});
+    };
+    applyTrafficLights(configContext.get().window.compact_mode);
+    configContext.onChange((cfg) => applyTrafficLights(cfg.window.compact_mode));
+  }
+
   // Keybindings
   const appWindow = getCurrentWindow();
   const syncWindowChromeState = async () => {

--- a/src/config/ConfigContext.ts
+++ b/src/config/ConfigContext.ts
@@ -2,7 +2,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 
 export interface AppConfig {
-  window: { opacity: number; padding: { x: number; y: number }; decorations: string; startup_mode: string };
+  window: { opacity: number; padding: { x: number; y: number }; decorations: string; startup_mode: string; compact_mode: boolean };
   font: { family: string; size: number; builtin_box_drawing: boolean };
   colors: {
     primary: { background: string; foreground: string };
@@ -28,7 +28,7 @@ export interface AppConfig {
     always_confirm_broadcast: boolean;
     always_confirm_multi_step: boolean;
   };
-  waterfall: { row_height_mode: string; fixed_row_height: number; scroll_snap: boolean; new_pane_focus: boolean; note_width: number; pane_min_width: number };
+  waterfall: { row_height_mode: string; fixed_row_height: number; scroll_snap: boolean; new_pane_focus: boolean; note_width: number; pane_min_width: number; show_note_button: boolean };
   persistence: { keep_alive: boolean; scrollback_lines: number; save_scrollback_on_exit: boolean };
 }
 
@@ -144,6 +144,13 @@ class ConfigContext {
     root.style.setProperty('--window-padding-x', `${c.window.padding.x}px`);
     root.style.setProperty('--window-padding-y', `${c.window.padding.y}px`);
     root.style.setProperty('--window-opacity', String(c.window.opacity));
+
+    document.body.dataset.showNoteBtn = c.waterfall.show_note_button !== false ? 'true' : 'false';
+    document.body.dataset.compact = c.window.compact_mode ? 'true' : 'false';
+
+    // Recalc terminal layout after any config change (compact mode toggling
+    // changes the visible height; font/padding changes affect row thresholds).
+    requestAnimationFrame(() => window.dispatchEvent(new Event('resize')));
 
     // Compute rgba background so CSS can apply opacity without dimming text.
     // Hex must be 6-char (#rrggbb); fall back to opaque if malformed.

--- a/src/help/helpContent.ts
+++ b/src/help/helpContent.ts
@@ -166,7 +166,7 @@ export function getCheatSheetSections(options: {
         { shortcuts: ['Shift+W'], description: 'Move to the previous pane in the current row' },
         { shortcuts: ['Ctrl+D', 'Ctrl+U'], description: 'Scroll the active terminal by half a page in Normal mode' },
         { shortcuts: ['Ctrl+F', 'Ctrl+B'], description: 'Scroll the active terminal by a full page in Normal mode' },
-        { shortcuts: ['G', 'GG'], description: 'Jump to the bottom or top of the active terminal scrollback' },
+        { shortcuts: ['G', 'GG'], description: 'Jump to the bottom or top of the workspace' },
       ],
     },
     {

--- a/src/settings/SettingsPanel.ts
+++ b/src/settings/SettingsPanel.ts
@@ -404,6 +404,7 @@ const SECTIONS: Section[] = [
           { path: 'window.padding.y',    label: 'Padding Y',     type: 'number', min: 0, max: 80 },
           { path: 'window.decorations',  label: 'Decorations',   type: 'select', opts: ['full','none','transparent','buttonless'] },
           { path: 'window.startup_mode', label: 'Startup mode',  type: 'select', opts: ['windowed','maximized','fullscreen','simpleFullscreen'] },
+          { path: 'window.compact_mode', label: 'Compact mode',  type: 'checkbox', desc: 'Hide the top toolbar and pane headers — only the workspace and input bar remain' },
         ],
       },
       {
@@ -553,6 +554,7 @@ const SECTIONS: Section[] = [
           { path: 'waterfall.new_pane_focus',   label: 'Focus new pane',   type: 'checkbox' },
           { path: 'waterfall.note_width',       label: 'Note pane width',  type: 'number', min: 120, max: 800, desc: 'px — default width of the note pane' },
           { path: 'waterfall.pane_min_width',   label: 'Pane min width',   type: 'number', min: 80,  max: 600, desc: 'px — minimum width for terminal panes (enforced during drag resize)' },
+          { path: 'waterfall.show_note_button', label: 'Show note button',  type: 'checkbox', desc: 'Show ✎ on row hover to quickly open the note pane' },
         ],
       },
     ],

--- a/src/style.css
+++ b/src/style.css
@@ -128,6 +128,41 @@ html, body {
   background: color-mix(in srgb, var(--accent) 8%, transparent 92%);
 }
 
+/* ── Compact mode — hides toolbar, pane headers, and row borders ──── */
+body[data-compact="true"] .app-header  { display: none; }
+body[data-compact="true"] .pane-header { display: none; }
+/* Extra top breathing room — no header above the first row in compact mode.
+   Use margin-top (not padding-top) so clientHeight stays correct for
+   recalcRowHeights(), which derives row heights from the element's clientHeight. */
+body[data-compact="true"] .waterfall-area {
+  margin-top: 14px;
+  padding-bottom: calc(var(--window-padding-y) + var(--workspace-bottom-safe-gap));
+  scroll-padding-top: var(--window-padding-y);
+  scroll-padding-bottom: calc(var(--window-padding-y) + var(--workspace-bottom-safe-gap));
+}
+/* Hide note header in compact mode so the textarea aligns with terminal content */
+body[data-compact="true"] .row-note-header { display: none; }
+
+/* Suppress decorative glow on inactive rows; keep a hairline border for boundaries */
+body[data-compact="true"] .terminal-row:not(:has(.terminal-pane.active)) {
+  border-color: color-mix(in srgb, var(--border) 30%, transparent 70%);
+  box-shadow: none;
+}
+/* Pane-level active indicator: 2px inset bar at top replaces the hidden header strip */
+body[data-compact="true"][data-mode="normal"] .terminal-pane.active,
+body[data-compact="true"][data-mode="pane-selector"] .terminal-pane.active {
+  box-shadow: inset 0 2px 0 var(--blue);
+}
+body[data-compact="true"][data-mode="insert"] .terminal-pane.active {
+  box-shadow: inset 0 2px 0 var(--green);
+}
+body[data-compact="true"][data-mode="terminal"] .terminal-pane.active {
+  box-shadow: inset 0 2px 0 var(--cyan);
+}
+body[data-compact="true"][data-mode="ai"] .terminal-pane.active {
+  box-shadow: inset 0 2px 0 var(--magenta);
+}
+
 /* ── Main area ────────────────────────────────────────────────────── */
 .app-main {
   flex: 1;
@@ -227,6 +262,7 @@ html, body {
 
 /* ── Waterfall Area ───────────────────────────────────────────────── */
 .waterfall-area {
+  --workspace-bottom-safe-gap: 0px;
   flex: 1;
   overflow-y: auto;
   display: flex;
@@ -247,6 +283,7 @@ html, body {
   flex-shrink: 0;
   gap: 0;
   position: relative;
+  isolation: isolate;
   border: 1px solid color-mix(in srgb, var(--border) 65%, transparent 35%);
   border-radius: 10px;
   overflow: hidden;
@@ -254,28 +291,50 @@ html, body {
   transition: border-color 0.18s, box-shadow 0.18s;
   /* height is set dynamically by JS */
 }
-
-/* Row-level active glow — uses :has() to target the row containing the active pane */
+/* Row-level active indicator — ::after overlay with z-index above pane-headers.
+   Using border-color alone is unreliable: the pane-header's background covers the
+   row's top edge, making the indicator invisible when the row is at the viewport top.
+   The ::after pseudo-element renders on top of all children and is always visible. */
+.terminal-row::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border: 1px solid transparent;
+  border-radius: 9px; /* row is 10px; we're inside the 1px border */
+  pointer-events: none;
+  z-index: 100;
+  opacity: 0;
+  transition: border-color 0.18s, opacity 0.18s;
+}
 body[data-mode="normal"] .terminal-row:has(.terminal-pane.active),
 body[data-mode="pane-selector"] .terminal-row:has(.terminal-pane.active) {
-  border-color: var(--blue);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--blue) 20%, transparent 80%),
-              0 4px 28px color-mix(in srgb, var(--blue) 10%, transparent 90%);
+  box-shadow: 0 4px 28px color-mix(in srgb, var(--blue) 10%, transparent 90%);
+}
+body[data-mode="normal"] .terminal-row:has(.terminal-pane.active)::after,
+body[data-mode="pane-selector"] .terminal-row:has(.terminal-pane.active)::after {
+  border-color: color-mix(in srgb, var(--blue) 70%, transparent 30%);
+  opacity: 1;
 }
 body[data-mode="insert"] .terminal-row:has(.terminal-pane.active) {
-  border-color: var(--green);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--green) 20%, transparent 80%),
-              0 4px 28px color-mix(in srgb, var(--green) 10%, transparent 90%);
+  box-shadow: 0 4px 28px color-mix(in srgb, var(--green) 10%, transparent 90%);
+}
+body[data-mode="insert"] .terminal-row:has(.terminal-pane.active)::after {
+  border-color: color-mix(in srgb, var(--green) 70%, transparent 30%);
+  opacity: 1;
 }
 body[data-mode="terminal"] .terminal-row:has(.terminal-pane.active) {
-  border-color: var(--cyan);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--cyan) 20%, transparent 80%),
-              0 4px 28px color-mix(in srgb, var(--cyan) 10%, transparent 90%);
+  box-shadow: 0 4px 28px color-mix(in srgb, var(--cyan) 10%, transparent 90%);
+}
+body[data-mode="terminal"] .terminal-row:has(.terminal-pane.active)::after {
+  border-color: color-mix(in srgb, var(--cyan) 70%, transparent 30%);
+  opacity: 1;
 }
 body[data-mode="ai"] .terminal-row:has(.terminal-pane.active) {
-  border-color: var(--magenta);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--magenta) 20%, transparent 80%),
-              0 4px 28px color-mix(in srgb, var(--magenta) 10%, transparent 90%);
+  box-shadow: 0 4px 28px color-mix(in srgb, var(--magenta) 10%, transparent 90%);
+}
+body[data-mode="ai"] .terminal-row:has(.terminal-pane.active)::after {
+  border-color: color-mix(in srgb, var(--magenta) 70%, transparent 30%);
+  opacity: 1;
 }
 
 /* ── Terminal Pane — panel inside the row, divided by thin separators ── */
@@ -294,9 +353,8 @@ body[data-mode="ai"] .terminal-row:has(.terminal-pane.active) {
 }
 .terminal-pane:last-child { border-right: none; }
 
-/* When resize handles are present, suppress pane border-right/left — the handle provides visual separation */
+/* When resize handles are present, the handle provides visual separation — suppress pane borders */
 .terminal-row:has(.pane-resize-handle) .terminal-pane { border-right: none; }
-.terminal-row:has(.pane-resize-handle) .row-note-pane { border-left: none; }
 
 /* ── Pane resize handle ───────────────────────────────────────────── */
 .pane-resize-handle {
@@ -339,26 +397,27 @@ body[data-mode="ai"] .terminal-row:has(.terminal-pane.active) {
   transition: background 0.15s, border-bottom-color 0.15s;
 }
 
-/* Active pane: colored top strip on header + subtle header tint */
+/* Active pane: colored top strip on header + subtle header tint.
+   Uses inset box-shadow instead of border-top to avoid overflowing the row boundary. */
 body[data-mode="normal"] .terminal-pane.active .pane-header,
 body[data-mode="pane-selector"] .terminal-pane.active .pane-header {
   background: color-mix(in srgb, var(--bg) 78%, var(--blue) 22%);
-  border-top: 2px solid var(--blue);
+  box-shadow: inset 0 2px 0 var(--blue);
   border-bottom-color: color-mix(in srgb, var(--blue) 28%, transparent 72%);
 }
 body[data-mode="insert"] .terminal-pane.active .pane-header {
   background: color-mix(in srgb, var(--bg) 78%, var(--green) 22%);
-  border-top: 2px solid var(--green);
+  box-shadow: inset 0 2px 0 var(--green);
   border-bottom-color: color-mix(in srgb, var(--green) 28%, transparent 72%);
 }
 body[data-mode="terminal"] .terminal-pane.active .pane-header {
   background: color-mix(in srgb, var(--bg) 76%, var(--cyan) 24%);
-  border-top: 2px solid var(--cyan);
+  box-shadow: inset 0 2px 0 var(--cyan);
   border-bottom-color: color-mix(in srgb, var(--cyan) 32%, transparent 68%);
 }
 body[data-mode="ai"] .terminal-pane.active .pane-header {
   background: color-mix(in srgb, var(--bg) 78%, var(--magenta) 22%);
-  border-top: 2px solid var(--magenta);
+  box-shadow: inset 0 2px 0 var(--magenta);
   border-bottom-color: color-mix(in srgb, var(--magenta) 28%, transparent 72%);
 }
 
@@ -414,24 +473,24 @@ body[data-mode="ai"] .terminal-pane.active .pane-header {
 
 /* ── Row Note ─────────────────────────────────────────────────────── */
 
-/* Note pane — rightmost panel in the row, same structure as terminal-pane */
+/* Note pane — rightmost panel in the row, visually distinct from terminals.
+   No border-left: the resize handle already provides physical separation. */
 .row-note-pane {
   flex: 0 0 280px; /* default; overridden by JS from config.waterfall.note_width */
   display: flex;
   flex-direction: column;
   border: none;
-  border-left: 1px solid color-mix(in srgb, var(--border) 50%, transparent 50%);
   border-radius: 0;
   overflow: hidden;
-  background: var(--bg);
+  background: color-mix(in srgb, var(--yellow) 4%, var(--bg) 96%);
   min-width: 0;
 }
 
-/* Header matches .pane-header exactly, with a yellow title as the only difference */
+/* Header — amber-tinted to match the note pane background */
 .row-note-header {
   height: 30px;
-  background: color-mix(in srgb, var(--surface2) 80%, var(--bg) 20%);
-  border-bottom: 1px solid color-mix(in srgb, var(--border) 55%, transparent 45%);
+  background: color-mix(in srgb, var(--yellow) 8%, var(--surface2) 92%);
+  border-bottom: 1px solid color-mix(in srgb, var(--yellow) 25%, transparent 75%);
   display: flex;
   align-items: center;
   padding: 0 10px;
@@ -488,6 +547,40 @@ body[data-mode="ai"] .terminal-pane.active .pane-header {
 .row-note-textarea::-webkit-scrollbar { width: 3px; }
 .row-note-textarea::-webkit-scrollbar-thumb { background: var(--border); }
 
+/* ── Row note toggle button ──────────────────────────────────────────── */
+/* Sits just left of the pane close button; appears on row hover.        */
+.row-note-toggle {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  width: 22px;
+  height: 22px;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--surface2) 85%, var(--bg) 15%);
+  border: 1px solid color-mix(in srgb, var(--border) 60%, transparent 40%);
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s, background 0.15s;
+  font-family: var(--font-family);
+  line-height: 1;
+}
+.terminal-row:hover .row-note-toggle { opacity: 0.55; }
+.terminal-row:hover .row-note-toggle:hover { opacity: 1; color: var(--yellow); }
+/* Always visible when the row has saved note content */
+.terminal-row[data-has-note="true"] .row-note-toggle { opacity: 0.75; color: var(--yellow); }
+.terminal-row[data-has-note="true"] .row-note-toggle:hover { opacity: 1; }
+/* Hide when the note pane is already open */
+.terminal-row:has(.row-note-pane) .row-note-toggle { display: none; }
+/* Hidden via settings */
+body[data-show-note-btn="false"] .row-note-toggle { display: none; }
+
 .term-container {
   flex: 1;
   overflow: hidden;
@@ -498,8 +591,7 @@ body[data-mode="ai"] .terminal-pane.active .pane-header {
 /* xterm overrides */
 .xterm { height: 100%; }
 .xterm-viewport { overscroll-behavior: contain; }
-.xterm-viewport::-webkit-scrollbar { width: 3px; }
-.xterm-viewport::-webkit-scrollbar-thumb { background: var(--border); }
+.xterm-viewport::-webkit-scrollbar { display: none; }
 
 /* ── Pane Context Menu ────────────────────────────────────────────── */
 .pane-ctx-menu {

--- a/src/waterfall/TerminalPane.ts
+++ b/src/waterfall/TerminalPane.ts
@@ -69,7 +69,6 @@ export class TerminalPane {
   private destroyed = false;
   private info: PaneInfo;
   private workspaceScrollModifier: WorkspaceScrollModifier;
-  private scrollMultiplier: number;
 
 
   constructor(info: PaneInfo, onClose: (id: number, prevRow: HTMLElement | null) => void) {
@@ -81,7 +80,6 @@ export class TerminalPane {
 
     const cfg = configContext.get();
     this.workspaceScrollModifier = this.normalizeScrollModifier(cfg.input.workspace_scroll_modifier);
-    this.scrollMultiplier = Math.max(1, cfg.scrolling.multiplier || 1);
     this.term = new Terminal({
       theme: configContext.getXtermTheme(cfg),
       fontFamily: `'${cfg.font.family}', 'Symbols Nerd Font Mono', 'JetBrains Mono', 'Fira Code', Consolas, monospace`,
@@ -124,7 +122,6 @@ export class TerminalPane {
     // Config changes
     configContext.onChange((cfg) => {
       this.workspaceScrollModifier = this.normalizeScrollModifier(cfg.input.workspace_scroll_modifier);
-      this.scrollMultiplier = Math.max(1, cfg.scrolling.multiplier || 1);
       this.term.options.theme       = configContext.getXtermTheme(cfg);
       this.term.options.fontSize    = cfg.font.size;
       this.term.options.fontFamily  = `'${cfg.font.family}', 'Symbols Nerd Font Mono', 'JetBrains Mono', 'Fira Code', Consolas, monospace`;
@@ -483,17 +480,18 @@ export class TerminalPane {
     const workspace = this.el.closest('.waterfall-area') as HTMLElement | null;
     if (this.shouldRouteWheelToWorkspace(e)) {
       if (!workspace) return false;
-      if (sessionManager.getActivePaneId() !== this.paneId) {
-        void sessionManager.setActivePane(this.paneId);
-      }
       hintManager.record({ type: 'workspace-scroll-used' });
       document.dispatchEvent(new CustomEvent('workspace-scroll-used'));
       e.preventDefault();
       e.stopPropagation();
-      workspace.scrollBy({
-        top: deltaPixels * this.scrollMultiplier,
-        behavior: 'auto',
-      });
+      document.dispatchEvent(new CustomEvent('workspace-wheel-scroll', {
+        detail: {
+          deltaPixels,
+          paneId: this.paneId,
+          clientX: e.clientX,
+          clientY: e.clientY,
+        },
+      }));
       return false;
     }
 

--- a/src/waterfall/WaterfallArea.ts
+++ b/src/waterfall/WaterfallArea.ts
@@ -21,6 +21,8 @@ export class WaterfallArea {
   private panes: Map<number, TerminalPane> = new Map();
   private rowEls: HTMLElement[] = [];
   private rowNotes: Map<HTMLElement, string> = new Map();
+  private layoutObserver: ResizeObserver;
+  private scrollSettleTimer: ReturnType<typeof setTimeout> | null = null;
   private nextPaneId = 1;
   private prevCwd: Map<number, string> = new Map();
   private lastPointerPos: { x: number; y: number } | null = null;
@@ -29,6 +31,9 @@ export class WaterfallArea {
     this.el = document.createElement('div');
     this.el.className = 'waterfall-area';
     container.appendChild(this.el);
+    this.layoutObserver = new ResizeObserver(() => this.recalcRowHeights());
+    this.layoutObserver.observe(this.el);
+    this.el.addEventListener('scroll', () => this.scheduleEdgeSettle(), { passive: true });
 
     // React to session changes — also detect cwd changes for auto-renaming
     sessionManager.onChange((panes, activePaneId) => {
@@ -54,7 +59,6 @@ export class WaterfallArea {
         pane.setActive(pane.paneId === id);
       }
     });
-
     window.addEventListener('resize', () => this.recalcRowHeights());
 
     document.addEventListener('mousemove', (e) => {
@@ -100,10 +104,28 @@ export class WaterfallArea {
       const activeId = sessionManager.getActivePaneId();
       if (activeId != null) this.scrollToPane(activeId);
     });
+    document.addEventListener('workspace-wheel-scroll', (e: Event) => {
+      const { deltaPixels, paneId, clientX, clientY } = (e as CustomEvent<{
+        deltaPixels: number;
+        paneId?: number;
+        clientX?: number;
+        clientY?: number;
+      }>).detail;
+      this.routeWorkspaceWheel(deltaPixels, paneId, clientX, clientY);
+    });
 
     // Normal-mode vi scroll: j/k/gg/G/Ctrl+D/U/F/B dispatch this event
     document.addEventListener('normal-vi-scroll', (e: Event) => {
       const { cmd } = (e as CustomEvent<{ cmd: string }>).detail;
+      switch (cmd) {
+        case 'top':
+          this.jumpWorkspaceBoundary('top');
+          return;
+        case 'bottom':
+          this.jumpWorkspaceBoundary('bottom');
+          return;
+      }
+
       const pane = this.getActivePane();
       if (!pane) return;
       switch (cmd) {
@@ -113,13 +135,58 @@ export class WaterfallArea {
         case 'halfUp':    pane.scrollBy(-Math.floor(pane.rows / 2)); break;
         case 'pageDown':  pane.scrollBy(pane.rows);  break;
         case 'pageUp':    pane.scrollBy(-pane.rows); break;
-        case 'top':       pane.scrollToTop();    break;
-        case 'bottom':    pane.scrollToBottom(); break;
       }
     });
   }
 
+  private jumpWorkspaceBoundary(direction: 'top' | 'bottom') {
+    const targetPaneId = this.pickBoundaryPane(direction);
+    if (targetPaneId != null && sessionManager.getActivePaneId() !== targetPaneId) {
+      void sessionManager.setActivePane(targetPaneId);
+    }
+    if (direction === 'top') this.scrollWorkspaceToTop();
+    else this.scrollWorkspaceToBottom();
+  }
+
+  private pickBoundaryPane(direction: 'top' | 'bottom'): number | null {
+    const rows = this.getPanesByDOMRow();
+    if (rows.length === 0) return null;
+    const targetRow = direction === 'top' ? rows[0] : rows[rows.length - 1];
+    if (!targetRow || targetRow.length === 0) return null;
+
+    const activeId = sessionManager.getActivePaneId();
+    const activeEl = activeId != null ? this.getPane(activeId)?.el ?? null : null;
+    if (!activeEl || targetRow.length === 1) return targetRow[0].id;
+
+    const activeRect = activeEl.getBoundingClientRect();
+    const activeCenter = activeRect.left + activeRect.width / 2;
+    let targetId = targetRow[0].id;
+    let minDist = Infinity;
+    for (const pane of targetRow) {
+      const el = this.getPane(pane.id)?.el;
+      if (!el) continue;
+      const rect = el.getBoundingClientRect();
+      const dist = Math.abs((rect.left + rect.width / 2) - activeCenter);
+      if (dist < minDist) {
+        minDist = dist;
+        targetId = pane.id;
+      }
+    }
+    return targetId;
+  }
+
+  private scrollWorkspaceToTop() {
+    this.el.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  private scrollWorkspaceToBottom() {
+    const maxScrollTop = Math.max(this.el.scrollHeight - this.el.clientHeight, 0);
+    this.el.scrollTo({ top: maxScrollTop, behavior: 'smooth' });
+  }
+
   private recalcRowHeights() {
+    const bottomOcclusion = this.getBottomOcclusion();
+    this.el.style.setProperty('--workspace-bottom-safe-gap', `${bottomOcclusion}px`);
     const containerH = this.el.clientHeight || (window.innerHeight - 36 - 42);
     const cfg = configContext.get();
     const rowCount = this.rowEls.length;
@@ -151,6 +218,8 @@ export class WaterfallArea {
   }
 
   private scrollRowWindowIntoView(rowEl: HTMLElement, behavior: ScrollBehavior = 'smooth') {
+    const bottomOcclusion = this.getBottomOcclusion();
+    this.el.style.setProperty('--workspace-bottom-safe-gap', `${bottomOcclusion}px`);
     if (this.el.scrollHeight <= this.el.clientHeight + 1) {
       rowEl.scrollIntoView({ behavior, block: 'nearest' });
       return;
@@ -173,6 +242,81 @@ export class WaterfallArea {
     const startIndex = Math.min(Math.max(targetIndex - rowsPerViewport + 1, 0), maxStart);
     const top = Math.max(this.rowEls[startIndex].offsetTop - paddingY, 0);
     this.el.scrollTo({ top, behavior });
+  }
+
+  private getBottomOcclusion(): number {
+    if (!this.isCompactMode()) return 0;
+    const inputBarEl = document.querySelector('.input-bar-wrapper') as HTMLElement | null;
+    if (!inputBarEl) return 0;
+    const overlap = Math.ceil(this.el.getBoundingClientRect().bottom - inputBarEl.getBoundingClientRect().top);
+    return Math.max(overlap, 0);
+  }
+
+  private isCompactMode(): boolean {
+    return !!configContext.get().window.compact_mode;
+  }
+
+  private shouldSnapRows(): boolean {
+    return this.isCompactMode() || !!configContext.get().waterfall.scroll_snap;
+  }
+
+  private shouldAutoSettleRows(): boolean {
+    const cfg = configContext.get();
+    return !!cfg.waterfall.scroll_snap;
+  }
+
+  private scheduleEdgeSettle() {
+    if (!this.shouldAutoSettleRows()) return;
+    if (this.scrollSettleTimer) clearTimeout(this.scrollSettleTimer);
+    this.scrollSettleTimer = setTimeout(() => {
+      this.scrollSettleTimer = null;
+      this.snapScrollToNearestRow();
+    }, 80);
+  }
+
+  private snapScrollToNearestRow() {
+    if (this.rowEls.length === 0) return;
+    const maxScrollTop = Math.max(this.el.scrollHeight - this.el.clientHeight, 0);
+    if (maxScrollTop <= 0) return;
+    const snapPoints = this.getRowSnapPoints();
+    const currentTop = this.el.scrollTop;
+    let targetTop = snapPoints[0];
+    let minDist = Math.abs(currentTop - targetTop);
+    for (let i = 1; i < snapPoints.length; i += 1) {
+      const dist = Math.abs(currentTop - snapPoints[i]);
+      if (dist < minDist) {
+        minDist = dist;
+        targetTop = snapPoints[i];
+      }
+    }
+    if (Math.abs(targetTop - currentTop) > 1) {
+      this.el.scrollTo({ top: targetTop, behavior: 'auto' });
+    }
+  }
+
+  private getRowSnapPoints(): number[] {
+    const maxScrollTop = Math.max(this.el.scrollHeight - this.el.clientHeight, 0);
+    const paddingY = configContext.get().window.padding.y;
+    return this.rowEls
+      .map(rowEl => Math.max(rowEl.offsetTop - paddingY, 0))
+      .concat(maxScrollTop);
+  }
+
+  private routeWorkspaceWheel(deltaPixels: number, paneId?: number, clientX?: number, clientY?: number) {
+    if (deltaPixels === 0) return;
+    const hoveredPaneId = this.syncHoveredPaneFromPointer(clientX, clientY);
+    const targetPaneId = hoveredPaneId ?? paneId;
+    if (targetPaneId != null && Number.isFinite(targetPaneId) && sessionManager.getActivePaneId() !== targetPaneId) {
+      void sessionManager.setActivePane(targetPaneId);
+    }
+
+    const scaledDelta = deltaPixels * Math.max(1, configContext.get().scrolling.multiplier || 1);
+    this.el.scrollBy({ top: scaledDelta, behavior: 'auto' });
+    if (this.lastPointerPos) {
+      requestAnimationFrame(() => {
+        this.syncHoveredPaneFromPointer(this.lastPointerPos?.x, this.lastPointerPos?.y);
+      });
+    }
   }
 
   private normalizeScrollModifier(value: string | null | undefined): WorkspaceScrollModifier {
@@ -221,14 +365,71 @@ export class WaterfallArea {
     }
   }
 
-  private syncHoveredPaneFromPointer() {
-    if (!this.lastPointerPos) return;
-    const hovered = document.elementFromPoint(this.lastPointerPos.x, this.lastPointerPos.y) as HTMLElement | null;
-    const paneEl = hovered?.closest('.terminal-pane') as HTMLElement | null;
-    const paneId = paneEl?.dataset.paneId ? Number(paneEl.dataset.paneId) : null;
+  private syncHoveredPaneFromPointer(x = this.lastPointerPos?.x, y = this.lastPointerPos?.y): number | null {
+    if (x == null || y == null) return null;
+    this.lastPointerPos = { x, y };
+    const paneId = this.pickPaneFromPoint(x, y);
     if (paneId != null && Number.isFinite(paneId) && sessionManager.getActivePaneId() !== paneId) {
       void sessionManager.setActivePane(paneId);
     }
+    return paneId != null && Number.isFinite(paneId) ? paneId : null;
+  }
+
+  private pickPaneFromPoint(x: number, y: number): number | null {
+    const hovered = document.elementFromPoint(x, y) as HTMLElement | null;
+    const hoveredPaneId = this.paneIdFromElement(hovered?.closest('.terminal-pane') as HTMLElement | null);
+    if (hoveredPaneId != null) return hoveredPaneId;
+
+    const containerRect = this.el.getBoundingClientRect();
+    if (x < containerRect.left || x > containerRect.right || y < containerRect.top || y > containerRect.bottom) {
+      return null;
+    }
+
+    let targetRow: HTMLElement | null = null;
+    let bestVerticalDistance = Infinity;
+    for (const rowEl of this.rowEls) {
+      const rowRect = rowEl.getBoundingClientRect();
+      if (rowRect.bottom < containerRect.top || rowRect.top > containerRect.bottom) continue;
+      const verticalDistance = y < rowRect.top ? rowRect.top - y : y > rowRect.bottom ? y - rowRect.bottom : 0;
+      if (verticalDistance < bestVerticalDistance) {
+        bestVerticalDistance = verticalDistance;
+        targetRow = rowEl;
+        if (verticalDistance === 0) break;
+      }
+    }
+    return targetRow ? this.pickPaneInRow(targetRow, x) : null;
+  }
+
+  private pickPaneInRow(rowEl: HTMLElement, x: number): number | null {
+    const paneEls = Array.from(rowEl.children)
+      .filter((child): child is HTMLElement => child instanceof HTMLElement && child.classList.contains('terminal-pane'));
+    if (paneEls.length === 0) return null;
+
+    for (const paneEl of paneEls) {
+      const rect = paneEl.getBoundingClientRect();
+      if (x >= rect.left && x <= rect.right) {
+        const paneId = this.paneIdFromElement(paneEl);
+        if (paneId != null) return paneId;
+      }
+    }
+
+    let targetPaneId = this.paneIdFromElement(paneEls[0]);
+    let bestHorizontalDistance = Infinity;
+    for (const paneEl of paneEls) {
+      const rect = paneEl.getBoundingClientRect();
+      const center = rect.left + rect.width / 2;
+      const distance = Math.abs(center - x);
+      if (distance < bestHorizontalDistance) {
+        bestHorizontalDistance = distance;
+        targetPaneId = this.paneIdFromElement(paneEl);
+      }
+    }
+    return targetPaneId;
+  }
+
+  private paneIdFromElement(paneEl: HTMLElement | null): number | null {
+    const paneId = paneEl?.dataset.paneId ? Number(paneEl.dataset.paneId) : null;
+    return paneId != null && Number.isFinite(paneId) ? paneId : null;
   }
 
   private wheelDeltaToPixels(e: WheelEvent): number {
@@ -265,18 +466,11 @@ export class WaterfallArea {
     if (this.shouldRouteWheelToWorkspace(e)) {
       const paneEl = target.closest('.terminal-pane') as HTMLElement | null;
       const paneId = paneEl?.dataset.paneId ? Number(paneEl.dataset.paneId) : null;
-      if (paneId != null && Number.isFinite(paneId) && sessionManager.getActivePaneId() !== paneId) {
-        void sessionManager.setActivePane(paneId);
-      }
-
       hintManager.record({ type: 'workspace-scroll-used' });
       document.dispatchEvent(new CustomEvent('workspace-scroll-used'));
       e.preventDefault();
       e.stopPropagation();
-      this.el.scrollBy({
-        top: deltaPixels * Math.max(1, configContext.get().scrolling.multiplier || 1),
-        behavior: 'auto',
-      });
+      this.routeWorkspaceWheel(deltaPixels, paneId ?? undefined, e.clientX, e.clientY);
       return;
     }
 
@@ -540,7 +734,12 @@ export class WaterfallArea {
   scrollToPane(id: number) {
     const pane = this.panes.get(id);
     if (pane) {
-      pane.el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      const rowEl = pane.el.parentElement as HTMLElement | null;
+      if (rowEl?.classList.contains('terminal-row') && this.shouldSnapRows()) {
+        this.scrollRowWindowIntoView(rowEl, 'smooth');
+      } else {
+        pane.el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      }
     }
   }
 
@@ -605,8 +804,16 @@ export class WaterfallArea {
 
   private attachRowNote(rowEl: HTMLElement) {
     this.rowNotes.set(rowEl, '');
-    // No floating button — note is triggered via `m` key or right-click menu.
-    // A left-border accent on the row indicates when a note has content.
+    const btn = document.createElement('button');
+    btn.className = 'row-note-toggle';
+    btn.title = 'Toggle note (m)';
+    btn.textContent = '✎';
+    btn.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      this.toggleRowNote(rowEl);
+    });
+    rowEl.appendChild(btn);
   }
 
   toggleRowNote(rowEl: HTMLElement) {
@@ -685,8 +892,8 @@ export class WaterfallArea {
     document.dispatchEvent(new CustomEvent('focus-inputbar'));
   }
 
-  private _syncNoteBtn(_rowEl: HTMLElement, _text: string) {
-    // No-op: note pane itself is the visual indicator.
+  private _syncNoteBtn(rowEl: HTMLElement, text: string) {
+    rowEl.dataset.hasNote = text.trim().length > 0 ? 'true' : '';
   }
 
   private getTerminalPanes(rowEl: HTMLElement): HTMLElement[] {


### PR DESCRIPTION
## Summary

- add a compact workspace mode that hides the toolbar and pane headers while preserving row-level navigation and workspace scrolling behavior
- keep active row indicators visible in compact mode, add row note toggles, and support compact-aware workspace wheel routing
- sync gg/G help text with workspace navigation and restore row notes after all panes are rebuilt so notes stay pinned to the far right

## Testing

- [x] `npx tsc --noEmit`
- [x] `npx vite build`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] Manual verification completed

## Checklist

- [x] Scope is focused and reviewable
- [x] Docs updated if behavior changed
- [ ] Screenshots added for UI changes
- [x] No secrets or local-only config were committed