### PR TITLE
fix: suppress phantom IME-confirming keydown after compositionend

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,5 +128,5 @@ jobs:
         run: |
           VERSION="${TAG_NAME#v}"
           gh workflow run update-cask.yml \
-            --repo wangzewang/homebrew-tap \
+            --repo amoswzw/homebrew-tap \
             --field version="$VERSION"

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/wangzewang/fluxtty/actions/workflows/ci.yml"><img src="https://github.com/wangzewang/fluxtty/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
-  <a href="https://github.com/wangzewang/fluxtty/actions/workflows/codeql.yml"><img src="https://github.com/wangzewang/fluxtty/actions/workflows/codeql.yml/badge.svg" alt="CodeQL" /></a>
-  <a href="https://github.com/wangzewang/fluxtty/releases"><img src="https://img.shields.io/github/v/release/wangzewang/fluxtty" alt="Release" /></a>
+  <a href="https://github.com/amoswzw/fluxtty/actions/workflows/ci.yml"><img src="https://github.com/amoswzw/fluxtty/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="https://github.com/amoswzw/fluxtty/actions/workflows/codeql.yml"><img src="https://github.com/amoswzw/fluxtty/actions/workflows/codeql.yml/badge.svg" alt="CodeQL" /></a>
+  <a href="https://github.com/amoswzw/fluxtty/releases"><img src="https://img.shields.io/github/v/release/amoswzw/fluxtty" alt="Release" /></a>
   <img src="https://img.shields.io/badge/license-MIT-blue" alt="License" />
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey" alt="Platform" />
   <img src="https://img.shields.io/badge/Tauri-2.x-orange" alt="Tauri" />
@@ -24,7 +24,7 @@
 </p>
 
 <p align="center">
-  <a href="https://wangzewang.github.io/fluxtty/"><strong>Live demo and landing page →</strong></a>
+  <a href="https://amoswzw.github.io/fluxtty/"><strong>Live demo and landing page →</strong></a>
 </p>
 
 <video src="https://github.com/user-attachments/assets/6b9ba19d-14c2-43d3-8e6a-6d3353674bb6" controls autoplay loop muted width="100%"></video>
@@ -47,13 +47,13 @@
 ### Homebrew (macOS)
 
 ```bash
-brew tap wangzewang/tap
+brew tap amoswzw/tap
 brew install --cask fluxtty
 ```
 
 ### Download
 
-**[→ Download latest release](https://github.com/wangzewang/fluxtty/releases/latest)**
+**[→ Download latest release](https://github.com/amoswzw/fluxtty/releases/latest)**
 
 | Platform | File |
 |---|---|
@@ -67,7 +67,7 @@ brew install --cask fluxtty
 **Prerequisites:** [Rust](https://rustup.rs/) 1.77+, [Node.js](https://nodejs.org/) 18+, [Tauri v2 prerequisites](https://tauri.app/start/prerequisites/)
 
 ```bash
-git clone https://github.com/wangzewang/fluxtty
+git clone https://github.com/amoswzw/fluxtty
 cd fluxtty
 npm install
 npm run tauri build

--- a/docs/index.html
+++ b/docs/index.html
@@ -841,7 +841,7 @@
     <li><a href="#modes">Modes</a></li>
     <li><a href="#config">Config</a></li>
     <li><a href="#keybindings">Keys</a></li>
-    <li><a href="https://github.com/wangzewang/fluxtty" class="nav-cta">GitHub</a></li>
+    <li><a href="https://github.com/amoswzw/fluxtty" class="nav-cta">GitHub</a></li>
   </ul>
 </nav>
 
@@ -863,7 +863,7 @@
         <span class="prompt-char">$</span>&nbsp;<span class="prompt-cmd">fluxtty</span><span class="cursor"></span>
       </p>
       <div class="hero-actions">
-        <a href="https://github.com/wangzewang/fluxtty" class="btn-primary">
+        <a href="https://github.com/amoswzw/fluxtty" class="btn-primary">
           <svg width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
           View on GitHub
         </a>
@@ -1274,38 +1274,38 @@
   <h2>Download fluxtty</h2>
   <p class="section-sub" style="text-align:center">
     Pre-built binaries for macOS, Linux, and Windows.
-    <a href="https://github.com/wangzewang/fluxtty/releases">See all releases →</a>
+    <a href="https://github.com/amoswzw/fluxtty/releases">See all releases →</a>
   </p>
   <div class="download-pills">
-    <a href="https://github.com/wangzewang/fluxtty/releases/download/v0.1.1/fluxtty_0.1.0_aarch64.dmg" class="download-pill">
+    <a href="https://github.com/amoswzw/fluxtty/releases/download/v0.1.1/fluxtty_0.1.0_aarch64.dmg" class="download-pill">
       <span class="download-pill-platform"></span>
       <div class="download-pill-info">
         <span class="download-pill-name">macOS Apple Silicon</span>
         <span class="download-pill-ext">.dmg · aarch64</span>
       </div>
     </a>
-    <a href="https://github.com/wangzewang/fluxtty/releases/download/v0.1.1/fluxtty_0.1.0_x64.dmg" class="download-pill">
+    <a href="https://github.com/amoswzw/fluxtty/releases/download/v0.1.1/fluxtty_0.1.0_x64.dmg" class="download-pill">
       <span class="download-pill-platform"></span>
       <div class="download-pill-info">
         <span class="download-pill-name">macOS Intel</span>
         <span class="download-pill-ext">.dmg · x64</span>
       </div>
     </a>
-    <a href="https://github.com/wangzewang/fluxtty/releases/download/v0.1.1/fluxtty_0.1.0_amd64.deb" class="download-pill">
+    <a href="https://github.com/amoswzw/fluxtty/releases/download/v0.1.1/fluxtty_0.1.0_amd64.deb" class="download-pill">
       <span class="download-pill-platform">🐧</span>
       <div class="download-pill-info">
         <span class="download-pill-name">Linux</span>
         <span class="download-pill-ext">.deb · amd64</span>
       </div>
     </a>
-    <a href="https://github.com/wangzewang/fluxtty/releases/download/v0.1.1/fluxtty_0.1.0_amd64.AppImage" class="download-pill">
+    <a href="https://github.com/amoswzw/fluxtty/releases/download/v0.1.1/fluxtty_0.1.0_amd64.AppImage" class="download-pill">
       <span class="download-pill-platform">🐧</span>
       <div class="download-pill-info">
         <span class="download-pill-name">Linux AppImage</span>
         <span class="download-pill-ext">.AppImage · amd64</span>
       </div>
     </a>
-    <a href="https://github.com/wangzewang/fluxtty/releases/download/v0.1.1/fluxtty_0.1.0_x64-setup.exe" class="download-pill">
+    <a href="https://github.com/amoswzw/fluxtty/releases/download/v0.1.1/fluxtty_0.1.0_x64-setup.exe" class="download-pill">
       <span class="download-pill-platform">🪟</span>
       <div class="download-pill-info">
         <span class="download-pill-name">Windows</span>
@@ -1320,13 +1320,13 @@
   <div class="footer-inner">
     <span class="footer-logo">flux<span>tty</span></span>
     <div class="footer-links">
-      <a href="https://github.com/wangzewang/fluxtty">GitHub</a>
-      <a href="https://github.com/wangzewang/fluxtty/releases">Releases</a>
-      <a href="https://github.com/wangzewang/fluxtty/blob/main/CONTRIBUTING.md">Contributing</a>
-      <a href="https://github.com/wangzewang/fluxtty/blob/main/LICENSE">MIT License</a>
+      <a href="https://github.com/amoswzw/fluxtty">GitHub</a>
+      <a href="https://github.com/amoswzw/fluxtty/releases">Releases</a>
+      <a href="https://github.com/amoswzw/fluxtty/blob/main/CONTRIBUTING.md">Contributing</a>
+      <a href="https://github.com/amoswzw/fluxtty/blob/main/LICENSE">MIT License</a>
     </div>
     <div>
-      <a href="https://github.com/wangzewang/fluxtty" class="star-btn">
+      <a href="https://github.com/amoswzw/fluxtty" class="star-btn">
         <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25z"/></svg>
         Star on GitHub
       </a>

--- a/src/input/InputBar.ts
+++ b/src/input/InputBar.ts
@@ -87,6 +87,7 @@ export class InputBar {
   private normalGgPending = false;
   private normalGgTimer: ReturnType<typeof setTimeout> | null = null;
   private isComposing = false;
+  private compositionJustEnded = false;
   private liveTypingMirrorSynced = true;
 
   // Normal mode: inline command sub-state (activated by ':')
@@ -204,6 +205,7 @@ export class InputBar {
 
   private handleCompositionEnd(e: CompositionEvent) {
     this.isComposing = false;
+    this.compositionJustEnded = true;
     const mode = modeManager.getMode();
     if (mode.type !== 'insert') return;
     if (!configContext.get().input.live_typing) return;
@@ -264,6 +266,20 @@ export class InputBar {
   }
 
   private handleKeyDown(e: KeyboardEvent) {
+    // After compositionend, the IME-confirming key (e.g. space, number) fires a
+    // keydown with isComposing=false. Swallow single printable keys here to
+    // prevent phantom spaces or digits from appearing in the input or being
+    // forwarded to the PTY.
+    if (this.compositionJustEnded && !e.isComposing) {
+      this.compositionJustEnded = false;
+      if (e.key.length === 1) {
+        e.preventDefault();
+        return;
+      }
+    } else {
+      this.compositionJustEnded = false;
+    }
+
     const composing = e.isComposing || this.isComposing;
 
     // ── Pane selector navigation ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- On macOS, pressing space (or a digit) to confirm a Chinese Pinyin IME candidate fires `compositionend` first, then a `keydown` with `isComposing=false` — bypassing the existing composition guard
- In buffered Insert mode this caused a literal space to be appended to the input field (and sent to the PTY on Enter)
- In live_typing mode the Chinese character was sent via `compositionend`, then the confirming space was sent again as a second keystroke

## Fix

Add a `compositionJustEnded` flag:
- Set to `true` in `handleCompositionEnd`
- Checked at the top of `handleKeyDown`: if set and the key is a single printable character (`key.length === 1`), call `preventDefault()` and skip — this is the IME-confirming key whose text was already committed by the browser
- Special keys (Enter, Escape, Backspace, etc.) are unaffected

## Test plan

- [ ] Type Chinese in Insert mode (buffered, default): confirm candidates with space — no phantom space in the submitted text
- [ ] Type Chinese in Insert mode (live_typing: true): confirm candidates with space — only the Chinese character reaches the PTY, not the trailing space
- [ ] Normal typing (ASCII) in Insert mode is unaffected
- [ ] Enter/Escape/Ctrl-C after Chinese input still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)