### PR TITLE
chore: bump version to 0.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluxtty",
-  "version": "0.1.1",
+  "version": "0.1.7",
   "type": "module",
   "description": "Multi-session developer workspace terminal",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluxtty"
-version = "0.1.1"
+version = "0.1.7"
 description = "Multi-session developer workspace terminal"
 authors = ["fluxtty"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "fluxtty",
-  "version": "0.1.1",
+  "version": "0.1.7",
   "identifier": "dev.fluxtty.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
## Summary

- Update `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` from `0.1.1` to `0.1.7` to match the current release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)