### PR TITLE
feat: workspace pipeline actions, command-complete waiting & test scaffolding (v0.1.8)

### DIFF
--- a/future-plan.md
+++ b/future-plan.md
@@ -1,0 +1,330 @@
+# Future Plan
+
+This file translates `future.md` into an execution plan.
+
+The plan is intentionally staged so Fluxtty can keep shipping useful terminal
+features while gradually becoming an AI-native workspace.
+
+## Planning Goals
+
+- Keep the terminal and workspace strong even before advanced AI arrives.
+- Avoid a premature multi-agent architecture.
+- Add AI capabilities in layers instead of rewriting the product later.
+- Preserve optionality for a future detached runtime / daemon model.
+
+## Working Rules
+
+1. Do not block terminal quality on AI work.
+2. Do not make the UI the source of truth.
+3. Do not route all future automation through xterm directly.
+4. Do not build the heavy orchestration layer before the lower layers are ready.
+5. Do not rebuild what already exists — extract and formalize it instead.
+
+## Current State Assessment
+
+Before planning phases, be honest about what already exists:
+
+- `ai-handler.ts` already has a unified `executeAction()` function that both
+  the LLM and regex paths use. The workspace action layer is not missing — it
+  is just embedded in the wrong module.
+- `pty.rs` already injects shell hooks into zsh/bash/fish and tracks CWD via
+  OSC 7. Adding OSC 133 command lifecycle markers is a small extension of
+  existing code, not a new project.
+- `session.rs` already has a clean `PaneInfo` model and `SessionManager` — but
+  `PaneInfo` carries `pty_pid`, which couples session identity to process
+  lifetime and will block future persistence work.
+- `plan-executor.ts` silently overwrites any pending plan when a new one
+  arrives. This is a latent bug that needs fixing before AI mode becomes more
+  capable.
+- Every frontend-to-backend call uses Tauri `invoke()` directly with no
+  abstraction layer. There are already call sites in `ai-handler.ts`,
+  `SessionManager.ts`, `InputBar.ts`, and `WaterfallArea.ts`. Each new feature
+  adds more. The daemon split requires replacing this transport — without an
+  abstraction, that means touching every call site across the entire codebase.
+
+## Phase 1: Fix the Structural Coupling
+
+### Objective
+
+Remove the architectural problems that will block every later phase. No new
+user-visible features. Current behavior preserved exactly.
+
+### Scope
+
+- extract the workspace action layer from `ai-handler.ts`
+- decouple `ai-handler` from `WaterfallArea`
+- clean `PaneInfo` of PTY process state
+- fix the single-pending-plan limitation in `plan-executor`
+- move auto-rename logic out of `WaterfallArea`
+
+### Concrete Work
+
+**Introduce a transport abstraction (`src/transport.ts`)**
+
+Create a thin module that wraps Tauri `invoke` and `listen` behind a transport-
+agnostic interface:
+
+```typescript
+// src/transport.ts
+export const transport = {
+  send<T>(cmd: string, args?: unknown): Promise<T>,
+  listen<T>(event: string, handler: (payload: T) => void): Promise<() => void>,
+}
+```
+
+Today, both methods delegate to Tauri. Every existing `invoke()` and `listen()`
+call across the codebase is migrated to `transport.send()` and
+`transport.listen()`. When the daemon split happens, only this file changes.
+
+This is the first item in Phase 1 because every other piece of work touches IPC
+call sites — doing this first means those migrations land clean rather than
+needing a second pass.
+
+**Extract `WorkspaceActions` module (`src/workspace/WorkspaceActions.ts`)**
+
+Move `executeAction()` and its helpers (`findPane`, `actionDescription`) out of
+`ai-handler.ts` into a standalone module. This module is the single path for
+all workspace mutations — AI, keyboard shortcuts, and future automation all call
+it. `ai-handler.ts` becomes a thin layer that parses intent and calls actions.
+
+**Remove the `waterfallArea` reference from `ai-handler.ts`**
+
+`ai-handler.ts` currently holds a `WaterfallArea` reference and calls
+`tp.writeCommand()`, `waterfallArea.spawnPane()`, `waterfallArea.splitCurrentRow()`,
+and `tp.destroy()` directly. After extraction, `WorkspaceActions` owns these
+calls. `ai-handler` no longer imports or knows about `WaterfallArea`.
+
+**Move `pty_pid` out of `PaneInfo` (Rust)**
+
+In `session.rs`, remove `pty_pid: u32` from `PaneInfo`. Move the pane-id to
+PTY-pid mapping into `PtyManager`'s own internal `HashMap<u32, PtyHandle>`.
+`SessionManager` and `PtyManager` communicate through pane IDs only — no
+process handles cross the boundary.
+
+**Replace single-pending-plan with a queue (`plan-executor.ts`)**
+
+Replace `setPending` / `setPlan` with a proper queue. New plans are appended;
+confirmation resolves the head of the queue. The input bar shows the current
+head and its position in the queue if more than one is pending.
+
+**Move auto-rename logic out of `WaterfallArea`**
+
+The CWD-change detection and auto-rename logic currently lives inside
+`WaterfallArea`'s `sessionManager.onChange()` callback (lines 39–54). Move
+this into a dedicated `SessionObserver` that listens to `SessionManager` events
+directly. `WaterfallArea` should only react to state changes for rendering —
+it should not write back to `SessionManager`.
+
+### Success Criteria
+
+- no file outside `transport.ts` calls `invoke()` or `listen()` from Tauri directly
+- `ai-handler.ts` does not import `WaterfallArea` or `TerminalPane`
+- all workspace mutations go through `WorkspaceActions`
+- `PaneInfo` in Rust contains no PTY process fields
+- a second pending plan does not silently erase the first
+- `WaterfallArea` does not call `sessionManager.renamePane()`
+
+## Phase 2: Enrich Workspace State
+
+### Objective
+
+Make terminal and workspace state machine-readable. This is what allows AI to
+reason over the workspace without depending on raw ANSI text.
+
+### Scope
+
+- extend the existing shell integration with command lifecycle markers
+- surface structured terminal metadata through the session state model
+- give AI a proper context API instead of manually assembled text
+
+### Concrete Work
+
+**Add OSC 133 markers to the existing shell hooks (`pty.rs`)**
+
+`setup_zsh()`, `setup_bash()`, and `setup_fish()` already inject hooks for OSC
+7 CWD tracking. Add OSC 133 A/B/C/D sequences to the same hooks:
+
+- `133;A` — prompt start
+- `133;B` — command start (captures what the user typed)
+- `133;C` — command output start
+- `133;D;exitcode` — command end with exit code
+
+Parse these sequences in the PTY output reader and update `PaneInfo` fields:
+`last_command`, `last_exit_code`, `foreground_process_state`.
+
+**Extend `PaneInfo` with command metadata**
+
+Add to `PaneInfo` in `session.rs`:
+
+```rust
+pub last_command: Option<String>,
+pub last_exit_code: Option<i32>,
+pub alternate_screen: bool,    // true when a TUI (vim, htop) is active
+```
+
+These are populated by the OSC 133 parser, not by the frontend.
+
+**Replace manually assembled text in `buildSystemPrompt()`**
+
+`ai-handler.ts` currently builds the LLM system prompt by formatting
+`getAllPanes()` into a text string. Replace this with a proper
+`WorkspaceState.serialize()` call that produces a structured representation.
+The AI handler should not know how workspace state is formatted.
+
+**Expose AI-friendly pane context API**
+
+Add an IPC command `get_pane_context(pane_id)` that returns:
+
+- cwd
+- status (idle/running)
+- last command and exit code
+- alternate-screen state
+- role and group
+
+### Success Criteria
+
+- `buildSystemPrompt()` calls a serializer, not `getAllPanes()` directly
+- command exit codes appear in `PaneInfo` after a command completes
+- AI can distinguish a pane running vim (alternate screen) from an idle shell
+- no screen scraping required to get basic terminal context
+
+## Phase 3: Normalize Workspace Actions
+
+### Objective
+
+Keyboard shortcuts, UI buttons, and AI mode all use the same action path. This
+is mostly already done if Phase 1 is complete — this phase hardens it.
+
+### Scope
+
+- formalize the action schema
+- make actions loggable and replayable
+- ensure no direct component-to-component mutations remain
+
+### Concrete Work
+
+- define a formal `WorkspaceAction` TypeScript discriminated union type
+  (currently `ParsedAction` is an untyped object with a string `type` field)
+- add a simple action log: each dispatched action is appended to an in-memory
+  ring buffer with a timestamp and result
+- audit `InputBar` and `WaterfallArea` for any remaining direct mutations to
+  session state that bypass `WorkspaceActions`
+
+### Success Criteria
+
+- `WorkspaceAction` is a typed discriminated union, not `{ type: string; [k]: unknown }`
+- every workspace mutation appears in the action log
+- no component directly calls `invoke('session_rename', ...)` or equivalent
+  outside of `WorkspaceActions`
+
+## Phase 4: Deliver Minimal Useful AI Mode
+
+### Objective
+
+Ship an orchestrator-style AI mode that uses the infrastructure from phases
+1–3. Keep scope narrow — one AI, no child workers yet.
+
+### Scope
+
+- AI reads structured workspace state (from Phase 2)
+- AI calls workspace actions (through the module from Phase 1)
+- AI uses a proper confirmation queue (from Phase 1)
+- AI summarizes results in workspace terms
+
+### Concrete Work
+
+- update the LLM system prompt to use `WorkspaceState.serialize()`
+- update response handling to dispatch through `WorkspaceActions`
+- update the confirmation flow to use the action queue
+- add result summarization: after a plan executes, show exit codes and
+  output summaries from `PaneInfo`, not just "Done."
+
+### Success Criteria
+
+- AI mode is clearly useful for multi-session coordination
+- AI mode does not require heavy orchestration backend
+- AI responses reference actual command results, not just confirmations
+
+## Phase 5: Add Orchestration and Child AI
+
+### Objective
+
+Expand from AI-assisted workspace control into AI-managed workspace execution.
+
+### Scope
+
+- child AI workers
+- bounded worker roles
+- task routing
+- future workspace templates/specs
+
+### Concrete Work
+
+- define worker roles and ownership rules
+- introduce child AI execution paths
+- add task decomposition and aggregation
+- support workspace templates/specs
+
+### Success Criteria
+
+- AI mode becomes a real control plane
+- worker behavior is bounded and inspectable
+- the system is still layered, not entangled
+
+## Runtime and Persistence Strategy
+
+### Near Term
+
+- Phase 1 fixes `PaneInfo` to not carry `pty_pid` — this is the prerequisite
+  for all persistence work
+- do not build persistence before the session/PTY boundary is clean
+
+### Medium Term
+
+- prepare the Rust backend for process separation: `SessionManager` should be
+  serializable and loadable independently of `PtyManager`
+- avoid new code that assumes the UI window is the permanent owner of all live
+  PTYs
+
+### Long Term
+
+- introduce a detached runtime / daemon model: `SessionManager` and
+  `PtyManager` run in a background process; the UI connects and reconnects
+  without killing the PTYs
+
+## Recommended Immediate Next Steps
+
+In order:
+
+1. Introduce `src/transport.ts` and migrate all `invoke`/`listen` calls to it.
+   Small file, high leverage — every subsequent step lands cleaner because of it.
+2. Extract `WorkspaceActions` from `ai-handler.ts`. Unblocks AI/keyboard
+   convergence and removes the `WaterfallArea` dependency from AI code.
+3. Move `pty_pid` out of `PaneInfo` in `session.rs`. Required before any
+   persistence work.
+4. Replace the single-pending-plan model in `plan-executor` with a queue.
+5. Add OSC 133 markers to the existing shell hook injection in `pty.rs`. The
+   infrastructure is already there — this is a small addition.
+6. Move auto-rename logic out of `WaterfallArea`.
+
+## Things to Avoid
+
+- adding new `invoke()` call sites before `transport.ts` exists — each one
+  is another file to update during the daemon split
+- rebuilding what already exists (`executeAction` is the action layer seed —
+  extract it, do not rewrite it)
+- starting Phase 2 before `PaneInfo` is clean of process state
+- treating OSC 133 as a large project (it is a small extension of existing code)
+- adding new AI features while `plan-executor` can still silently drop plans
+- mixing runtime design, AI design, and UI polish into one large refactor
+
+## Review Questions
+
+- Is the terminal/workspace foundation still improving independently of AI?
+- Are we adding state and actions, or just adding more UI wiring?
+- Does each phase unlock the next one cleanly?
+- Is `PaneInfo` clean of PTY runtime fields?
+- Are we preserving the option to move toward a detached runtime later?
+- Is AI mode becoming a true control plane, not just a command relay?
+- Can the action queue handle concurrent plans without silent data loss?
+- Is all IPC going through `transport.ts`, or are new `invoke()` calls creeping in?

--- a/future.md
+++ b/future.md
@@ -1,0 +1,360 @@
+# Future Architecture
+
+## Direction
+
+Fluxtty should be built as a terminal-first workspace that can grow into an
+AI-native workspace over time.
+
+The order matters:
+
+1. Build a strong terminal and workspace foundation first.
+2. Expose structured state and explicit workspace actions.
+3. Add AI as a layer on top of that foundation.
+4. Add orchestration and child-AI capabilities later, without rewriting the
+   terminal core.
+
+The product goal is not "an AI that types into terminals".
+The product goal is "a workspace operating layer where terminal sessions are one
+kind of execution surface, and AI can gradually become the main control plane".
+
+## Core Principles
+
+- Terminal usability must stand on its own even if AI is disabled.
+- AI should read structured workspace state, not rely on screen scraping or DOM
+  inspection as the primary source of truth.
+- Workspace operations should be explicit actions, not ad hoc UI side effects.
+- New AI features should be additive layers, not force rewrites of the
+  terminal/workspace foundation.
+- Persistence and lifecycle design should leave room for a future detached
+  runtime or daemon model.
+
+## What Already Exists (Do Not Rebuild)
+
+Before planning new work, recognize what the codebase already provides.
+
+### The action protocol is already in embryonic form
+
+`ai-handler.ts` contains `ParsedAction` and a unified `executeAction()` function
+that both the LLM path and the regex parser path go through. This is already a
+workspace action bus — it just lives inside the AI handler instead of being a
+standalone module. The work is extraction and formalization, not a greenfield
+build.
+
+### Shell integration is already implemented
+
+`pty.rs` injects shell hooks into zsh, bash, and fish at spawn time, and already
+uses OSC 7 for CWD tracking. The infrastructure for OSC 133 command lifecycle
+markers (command start, command end, exit code) is a small addition to the
+existing hook injection — not a new project. This makes the "AI-ready terminal
+context" phase much closer than it appears.
+
+## Known Technical Debt (Address Early)
+
+### The IPC layer has no transport abstraction — this is the highest-priority debt
+
+Every frontend-to-backend call uses Tauri's `invoke()` directly, scattered
+across `ai-handler.ts`, `SessionManager.ts`, `InputBar.ts`, `WaterfallArea.ts`,
+and elsewhere:
+
+```typescript
+await invoke('pty_write', ...)
+await invoke('session_rename', ...)
+await invoke('pty_spawn', ...)
+```
+
+Tauri's `invoke` is window-bound. It only works when the Tauri WebView is alive.
+The daemon/runtime split described in the Persistence Strategy requires replacing
+this transport with something that can survive a window close — a Unix socket,
+WebSocket, or similar. By the time that work begins, there will be dozens of
+`invoke` call sites spread across every file in the codebase.
+
+The fix costs almost nothing now: a thin `src/transport.ts` module that today
+wraps Tauri invoke, but exposes a transport-agnostic interface. Every other file
+calls `transport.send()` instead of `invoke()` directly. When the daemon split
+happens, only `transport.ts` changes — not every call site.
+
+This is the one decision that compounds silently over time. Every new feature
+added before this abstraction exists is one more file to update later. Expensive
+enough means it never gets done, and the daemon model stays a permanent "long-
+term goal" instead of a realistic target.
+
+### `PaneInfo.pty_pid` couples session identity to process lifecycle
+
+`PaneInfo` in `session.rs` carries `pty_pid: u32`. This makes sense today, but
+it means session state and PTY process lifetime are fused into the same struct.
+When a PTY dies, this field becomes a stale reference. Any future work toward
+session persistence or a detached runtime will be blocked by this coupling.
+
+The fix: move `pty_pid` out of `PaneInfo` and into `PtyManager`'s own internal
+mapping. `PaneInfo` should represent pure session identity, not runtime process
+state.
+
+### `plan-executor` only holds one pending plan
+
+`planExecutor.setPlan()` and `setPending()` silently overwrite any existing
+pending plan. If the workspace AI produces a second plan while a first is
+waiting for confirmation, the first is dropped without notice. This needs a
+queue before the AI mode becomes more capable.
+
+## Target Layers
+
+### 1. Terminal Core
+
+Owns:
+
+- PTY lifecycle
+- pane and row layout
+- scrollback
+- focus and active-pane behavior
+- close/reopen behavior
+- resize behavior
+- session creation and destruction
+
+This layer should remain useful without any AI feature.
+
+### 2. Workspace State
+
+Owns the structured model that both UI and AI can consume.
+
+Examples of state that should live here:
+
+- pane id, name, group, role
+- cwd
+- active pane
+- row and layout structure
+- note content
+- session status
+- ownership metadata
+- recent command metadata
+- last exit code
+- foreground process metadata
+
+The key rule is that important workspace state should not exist only as pixels
+or terminal text. `PaneInfo` in `session.rs` is already this model — it just
+needs to be kept clean of runtime process fields (see `pty_pid` above).
+
+### 3. Workspace Actions
+
+All workspace mutations should go through explicit actions.
+
+Examples:
+
+- create pane
+- split row
+- focus pane
+- rename pane
+- move pane/group
+- run command
+- clear output
+- interrupt process
+- close pane
+- apply workspace template
+
+This gives a single control surface for keyboard shortcuts, UI buttons, AI
+mode, and future automation. The `executeAction()` function in `ai-handler.ts`
+is the seed of this layer — it needs to be extracted, not rebuilt.
+
+### 4. AI Interface
+
+AI mode should be the human-to-workspace interface, not just a smarter shell.
+
+Its responsibilities should be:
+
+- understand the user's goal
+- inspect workspace state
+- choose the right workspace actions
+- present plans and confirmations
+- summarize results
+
+It should not be tightly coupled to xterm internals or `WaterfallArea`.
+
+### 5. Orchestration Layer
+
+This is a later layer, not the starting point.
+
+It can eventually own:
+
+- child AI workers
+- task decomposition
+- plan execution
+- workspace templates/specs
+- multi-session coordination
+- detached runtime or daemon-backed persistence
+
+## Execution Model
+
+Fluxtty should not force every AI operation through an interactive PTY.
+
+Long term there should be multiple execution backends:
+
+### Task Runtime
+
+For one-shot, structured commands where exit code and complete output matter.
+
+Examples:
+
+- git status
+- npm test
+- cargo check
+- file inspection tasks
+
+### PTY Runtime
+
+For long-lived interactive work.
+
+Examples:
+
+- shell sessions
+- dev servers
+- REPLs
+- vim / lazygit / htop / other TUI apps
+
+### Child AI Runtime
+
+For future delegated workers with bounded ownership and isolated context.
+
+Examples:
+
+- coder worker
+- reviewer worker
+- researcher worker
+- ops worker
+
+## AI Product Model
+
+The intended AI-first model is:
+
+- one top-level orchestrator AI exposed through AI mode
+- multiple execution targets underneath it
+- child AIs added later as specialized workers
+
+This means AI mode should become the main human control plane for the
+workspace, but not the only runtime in the system.
+
+AI mode should eventually manage:
+
+- workspace creation
+- workspace structure
+- pane roles
+- task routing
+- status summaries
+- child AI assignment
+
+But the first version should stay much smaller and simpler.
+
+## Recommended Roadmap
+
+### Phase 1: Fix the Structural Coupling
+
+Address the architectural problems that will block every later phase.
+
+Priority areas:
+
+- extract `executeAction()` from `ai-handler.ts` into a standalone
+  `WorkspaceActions` module
+- route keyboard shortcuts through the same action module
+- move `pty_pid` out of `PaneInfo` into `PtyManager`'s internal mapping
+- replace the single-pending-plan model in `plan-executor` with a queue
+- move CWD auto-rename logic out of `WaterfallArea` into the session layer
+
+Goal: the workspace action layer exists as a real module; `ai-handler` no longer
+depends on `WaterfallArea`; session state can outlive a PTY process.
+
+### Phase 2: Enrich Workspace State
+
+Make workspace state complete enough for AI to reason over without depending on
+raw terminal text.
+
+Priority areas:
+
+- pane role metadata
+- command lifecycle metadata via OSC 133 (build on existing shell hook
+  infrastructure in `pty.rs`)
+- recent output summaries
+- idle/running state
+- foreground process metadata
+- AI-friendly pane context APIs
+
+Goal: AI can inspect terminal context without screen scraping. OSC 133 gives
+command start, output boundaries, and exit codes through the existing shell
+integration path — this is a small extension, not new infrastructure.
+
+### Phase 3: Minimal Useful AI Mode
+
+Add one orchestrator AI, but keep scope narrow.
+
+Priority areas:
+
+- AI mode reads structured workspace state (not manually assembled text)
+- AI mode calls workspace actions (through the module from Phase 1)
+- AI mode proposes plans with a proper confirmation queue
+- AI mode summarizes command and workspace results
+
+Goal: AI mode is clearly useful without requiring a heavy multi-agent
+architecture. The action queue and structured state from phases 1–2 make this
+clean.
+
+### Phase 4: Child AI and Workspace Orchestration
+
+Expand from AI-assisted workspace control into AI-managed workspace execution.
+
+Priority areas:
+
+- child AI workers
+- role-specific worker types
+- task routing
+- workspace spec/template support
+- richer planning and execution
+- detached runtime / daemon model
+
+Goal: the workspace becomes a true AI control plane.
+
+## Persistence Strategy
+
+There are two different persistence goals and they should stay separate.
+
+### A. Close/Reopen App Without Losing Live Work
+
+Long-term best solution:
+
+- split UI from runtime
+- keep PTYs and workspace runtime alive outside the UI process
+- allow the UI to detach and reattach
+
+This points toward a future daemon/runtime split. The prerequisite is that
+`PaneInfo` does not carry PTY process state (see the `pty_pid` issue above).
+Fixing that coupling should happen in Phase 1, before the daemon work begins.
+
+### B. Recover After Full System Shutdown
+
+This cannot preserve the same live PTYs and processes.
+
+After full shutdown/reboot, the best realistic outcome is:
+
+- restore workspace structure
+- restore metadata and notes
+- restore enough context to rebuild work
+
+It is not the same as preserving a live interactive process tree.
+
+## Explicit Non-Goals For Now
+
+- Do not make the product depend on AI availability to feel usable.
+- Do not make terminal screen scraping the primary architecture.
+- Do not force every action through interactive PTY sessions.
+- Do not make tmux/zellij the primary product abstraction.
+- Do not start with a heavy multi-agent system before the terminal core is
+  stable.
+
+## Design Check
+
+Any future change should satisfy most of these checks:
+
+- If AI is disabled, does the workspace still make sense?
+- Is the source of truth structured state rather than UI rendering?
+- Can keyboard/UI/AI all use the same action path?
+- Does this make future detached runtime support easier, not harder?
+- Is this additive, or does it secretly rewrite the foundation?
+- Does `PaneInfo` stay clean of PTY runtime fields?
+- Can the pending action queue handle more than one plan at a time?
+- Does this add another `invoke()` call site, or does it go through `transport.ts`?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "waterfallterm",
-  "version": "0.1.1",
+  "name": "fluxtty",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "waterfallterm",
-      "version": "0.1.1",
+      "name": "fluxtty",
+      "version": "0.1.7",
       "dependencies": {
         "@tauri-apps/api": "^2.5.0",
         "@xterm/addon-fit": "^0.11.0",
@@ -17,7 +17,8 @@
       "devDependencies": {
         "@tauri-apps/cli": "^2.10.1",
         "typescript": "^6.0.2",
-        "vite": "^8.0.8"
+        "vite": "^8.0.8",
+        "vitest": "^4.1.4"
       }
     },
     "node_modules/@emnapi/core": {
@@ -53,6 +54,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.3",
@@ -347,6 +355,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tauri-apps/api": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
@@ -585,6 +600,144 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xterm/addon-fit": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
@@ -612,6 +765,33 @@
         "addons/*"
       ]
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -620,6 +800,33 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -916,6 +1123,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -934,6 +1151,24 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1018,6 +1253,13 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1026,6 +1268,37 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -1043,6 +1316,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -1143,6 +1426,113 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,24 +1,27 @@
 {
   "name": "fluxtty",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "module",
   "description": "Multi-session developer workspace terminal",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
-    "@xterm/xterm": "^6.0.0",
+    "@tauri-apps/api": "^2.5.0",
     "@xterm/addon-fit": "^0.11.0",
-    "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-search": "^0.16.0",
-    "@tauri-apps/api": "^2.5.0"
+    "@xterm/addon-web-links": "^0.12.0",
+    "@xterm/xterm": "^6.0.0"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.10.1",
     "typescript": "^6.0.2",
-    "vite": "^8.0.8"
+    "vite": "^8.0.8",
+    "vitest": "^4.1.4"
   }
 }

--- a/solution.md
+++ b/solution.md
@@ -1,0 +1,642 @@
+# Fluxtty 架构调整方案
+
+本文基于 `future.md`、`future-plan.md` 和当前实现，整理在不改变现有功能的前提下，后续开发前应优先完成的架构调整。
+
+## 总体判断
+
+`future.md` 和 `future-plan.md` 的方向是正确的：Fluxtty 应先稳住终端和工作区基础，再把 AI 作为上层控制面逐步接入，而不是让 AI、xterm、UI 组件和 PTY 运行时互相耦合。
+
+当前最需要做的不是新增 AI 功能，而是把这些职责拆清楚：
+
+- UI 只负责渲染和交互。
+- Workspace State 负责结构化工作区状态。
+- Workspace Actions 负责所有工作区变更。
+- Transport 负责前后端通信。
+- PTY Runtime 负责进程和终端 I/O 生命周期。
+- AI 只负责理解意图、生成动作、展示计划和总结结果。
+
+目标依赖关系应调整为：
+
+```text
+UI / Keybindings / AI input
+        ↓
+WorkspaceActions / PlanQueue
+        ↓
+Workspace services / ports
+        ↓
+Transport
+        ↓
+Rust IPC / future daemon
+
+Rust PTY events
+        ↓
+Session / Workspace State
+        ↓
+UI render + AI context serializer
+```
+
+关键原则是：先用 adapter 包住现有实现，保持用户可见行为不变；等调用路径统一以后，再逐步把状态源从 DOM/UI 迁到 workspace state。
+
+## 当前主要耦合点
+
+### 1. IPC 调用直接散落在前端各处
+
+当前 `invoke()` 和 `listen()` 直接出现在多个模块里，例如：
+
+- `src/session/SessionManager.ts`
+- `src/waterfall/TerminalPane.ts`
+- `src/waterfall/WaterfallArea.ts`
+- `src/input/InputBar.ts`
+- `src/keybindings/KeybindingManager.ts`
+- `src/settings/SettingsPanel.ts`
+- `src/app.ts`
+- `src/ai/ai-handler.ts`
+- `src/ai/llm-client.ts`
+- `src/config/ConfigContext.ts`
+
+这会让未来 daemon/runtime split 成本很高。Tauri `invoke()` 是 window-bound 的，如果以后 UI 关闭但 PTY runtime 继续存在，直接散落的 IPC 调用会成为迁移阻力。
+
+### 2. Workspace action 已经存在，但困在 AI 模块里
+
+`src/ai/ai-handler.ts` 中已有 `ParsedAction`、`executeAction()`、`findPane()`、`actionDescription()`。这已经是 workspace action bus 的雏形。
+
+问题是它现在：
+
+- 位于 AI 模块内部。
+- 直接依赖 `WaterfallArea`。
+- 直接调用 `TerminalPane.writeCommand()`、`TerminalPane.destroy()`。
+- 直接调用 `sessionManager` 和 `invoke('pty_write')`。
+
+同时键盘快捷键、sidebar、header 按钮等路径并没有复用这条 action path，而是各自直接操作 UI、session 或 PTY。
+
+### 3. `WaterfallArea` 承担了过多职责
+
+当前 `WaterfallArea` 同时负责：
+
+- 行和 pane 的 DOM 布局。
+- row height 计算。
+- pane spawn。
+- active pane 的滚动定位。
+- row note 的 DOM 和状态。
+- CWD 变化后的自动重命名。
+- pane fallback focus。
+- 从 DOM 反推 snapshot 布局。
+
+这使它成为事实上的工作区控制器。后续如果 AI、键盘、持久化、daemon 都继续依赖它，UI 会继续成为 source of truth。
+
+### 4. `PaneInfo.pty_pid` 混入了运行时进程状态
+
+Rust `PaneInfo` 和 TypeScript `PaneInfo` 都包含 `pty_pid`。这把 session identity 和 PTY process lifecycle 绑定到一起。
+
+问题：
+
+- PTY 退出后 `pty_pid` 会变成陈旧引用。
+- session state 难以独立序列化。
+- detached runtime / daemon 模型会被阻塞。
+
+`PaneInfo` 应只表示可持久化、可结构化消费的 workspace state。PTY pid 应属于 `PtyManager` 内部映射。
+
+### 5. `plan-executor` 是单 pending plan
+
+`planExecutor.setPlan()` 和 `setPending()` 会互相覆盖。AI 以后能力增强后，如果第二个计划在第一个等待确认时产生，第一个会静默丢失。
+
+这不是功能扩展问题，而是后续 AI mode 的可靠性基础问题。
+
+### 6. `status` 没有真实运行时来源
+
+`PaneInfo.status` 有 `idle | running | error`，但当前缺少命令生命周期驱动。UI 和 AI 已经在使用这个字段，例如 sidebar running count、关闭确认、AI context。
+
+需要通过 OSC 133 或等价机制，把 command start、command end、exit code 等结构化状态写入 session model。
+
+### 7. 自动命名状态只存在前端内存里
+
+`AutoNamer` 使用前端 `Set<number>` 标记 auto-named pane。重启、恢复 snapshot 或未来 UI detach 后，这个状态会丢。
+
+建议把命名来源结构化进 `PaneInfo`，例如：
+
+```typescript
+name_source: 'auto' | 'manual'
+```
+
+或：
+
+```typescript
+auto_named: boolean
+```
+
+这样“用户手动重命名后锁定”才能成为可靠的 workspace state。
+
+## 分阶段调整方案
+
+## Phase 0：建立边界，不改变行为
+
+目标：保持现有功能不变，只调整调用路径和模块边界。
+
+### 0.1 新增 `src/transport.ts`
+
+新增统一 transport abstraction：
+
+```typescript
+export const transport = {
+  send<T>(cmd: string, args?: unknown): Promise<T>,
+  listen<T>(event: string, handler: (payload: T) => void): Promise<() => void>,
+}
+```
+
+当前实现只包装 Tauri：
+
+- `transport.send()` 内部调用 `invoke()`。
+- `transport.listen()` 内部调用 `listen()`，并把 Tauri event 解包成 payload。
+
+迁移规则：
+
+- 前端业务模块不再直接 import `@tauri-apps/api/core` 的 `invoke`。
+- 前端业务模块不再直接 import `@tauri-apps/api/event` 的 `listen`。
+- 窗口 API 如 `getCurrentWindow()` 可暂时保留，后续单独封装 `windowPort`。
+
+成功标准：
+
+- 除 `src/transport.ts` 外，没有业务文件直接调用 `invoke()` 或 `listen()`。
+- 现有 IPC command 名称和参数保持不变。
+
+### 0.2 新增 `src/workspace/WorkspaceActions.ts`
+
+把 `ai-handler.ts` 里的 action 执行能力抽出来，但不要简单把 `WaterfallArea` 依赖搬过去。
+
+应定义 ports：
+
+```typescript
+interface WorkspaceActionPorts {
+  session: SessionPort;
+  terminal: TerminalRuntimePort;
+  layout: WorkspaceLayoutPort;
+  viewport: WorkspaceViewportPort;
+  log?: ActionLogPort;
+}
+```
+
+初期 port 可以由现有对象适配：
+
+- `SessionPort` 由 `sessionManager` 实现。
+- `TerminalRuntimePort` 由 `TerminalPane` / transport 适配。
+- `WorkspaceLayoutPort` 由 `WaterfallArea` 适配。
+- `WorkspaceViewportPort` 由 `WaterfallArea.scrollToPane()` 适配。
+
+这样可以保持行为不变，同时避免新 action 层直接绑定 UI 类。
+
+建议 action 类型先从现有 `ParsedAction` 演进：
+
+```typescript
+type WorkspaceAction =
+  | { type: 'run'; target: string; cmd: string }
+  | { type: 'broadcast'; cmd: string }
+  | { type: 'run-group'; group: string; cmd: string }
+  | { type: 'new'; name?: string | null; group?: string | null }
+  | { type: 'rename'; target: string; name: string }
+  | { type: 'close'; target: string }
+  | { type: 'close-group'; group: string }
+  | { type: 'split' }
+  | { type: 'focus'; target: string }
+  | { type: 'group'; target: string; group: string }
+  | { type: 'note'; target: string; text: string }
+  | { type: 'clear'; target: string }
+  | { type: 'kill'; target: string };
+```
+
+成功标准：
+
+- `ai-handler.ts` 不再 import `WaterfallArea` 或 `TerminalPane`。
+- `executeAction()` 不再留在 `ai-handler.ts`。
+- AI、键盘、UI 按钮最终都能 dispatch 同一种 workspace action。
+
+### 0.3 收缩 `ai-handler.ts`
+
+`ai-handler.ts` 应只负责：
+
+- 构造 prompt。
+- 调用 LLM。
+- 解析 action block。
+- regex fallback intent parsing。
+- 把 action 交给 `WorkspaceActions`。
+
+不应负责：
+
+- spawn pane。
+- destroy pane。
+- write PTY。
+- scroll pane。
+- rename pane。
+- 操作 `WaterfallArea`。
+
+### 0.4 键盘、header、sidebar 逐步走 action path
+
+以下操作应改为 workspace action：
+
+- New terminal。
+- Split row。
+- Close pane。
+- Focus pane / row navigation。
+- Rename pane。
+- Group pane。
+- Paste to active pane。
+- Run command in pane。
+- Clear / kill。
+
+UI 可以继续保留 `confirm()`、`prompt()`、settings panel toggle 这类交互，但真正改变 workspace state 的部分应通过 `WorkspaceActions`。
+
+### 0.5 `PlanExecutor` 改为 `PlanQueue`
+
+把当前单槽 plan 改成队列：
+
+```typescript
+type PendingActionBatch = {
+  id: string;
+  title: string;
+  preview: string;
+  actions: WorkspaceAction[];
+  execute(): Promise<ActionResult[]>;
+}
+```
+
+行为：
+
+- 新 plan append 到队尾。
+- `y/n` 只处理队首。
+- preview 显示当前队首。
+- 如果队列长度大于 1，提示当前位置，例如 `Plan 1/3`。
+
+成功标准：
+
+- 第二个 pending plan 不会覆盖第一个。
+- 取消一个 plan 不会清空整个队列，除非用户明确执行 clear all。
+- AI mode 和 normal `:` command 共用同一确认队列。
+
+## Phase 1：清理状态边界
+
+目标：让 session state 能独立于 PTY process 和 UI DOM 存在。
+
+### 1.1 移除 `PaneInfo.pty_pid`
+
+Rust：
+
+- 从 `src-tauri/src/session.rs` 的 `PaneInfo` 移除 `pty_pid`。
+- `SessionManager.create_pane()` 不再接收 `pty_pid`。
+- `PtyManager` 内部维护 `pane_id -> PtyProcess`。
+- 如果需要 pid，用 runtime-only API 查询，不放进 `PaneInfo`。
+
+TypeScript：
+
+- 从 `src/session/types.ts` 的 `PaneInfo` 移除 `pty_pid`。
+- 删除前端 fallback info 里的 `pty_pid: 0`。
+
+成功标准：
+
+- `PaneInfo` 只包含 workspace/session metadata。
+- session snapshot 不包含 PTY process id。
+- `SessionManager` 和 `PtyManager` 只通过 pane id 协作。
+
+### 1.2 新增 `SessionObserver` / `WorkspaceObserver`
+
+把以下逻辑从 UI 组件中移出：
+
+- CWD 变化后自动重命名。
+- significant command 自动重命名。
+- agent detection 结果同步到 session state。
+- pane close 后清理 auto-namer / agent detector 内部状态。
+
+建议新增：
+
+```text
+src/session/SessionObserver.ts
+src/session/PaneNamingPolicy.ts
+```
+
+`WaterfallArea` 的 `sessionManager.onChange()` 只负责：
+
+- 找到对应 `TerminalPane`。
+- 调用 `pane.updateInfo(info)`。
+- 更新 active visual state。
+
+不应写回 `sessionManager.renamePane()`。
+
+### 1.3 命名来源结构化
+
+在 `PaneInfo` 添加命名来源：
+
+```typescript
+name_source: 'auto' | 'manual'
+```
+
+Rust 同步添加：
+
+```rust
+pub name_source: PaneNameSource
+```
+
+行为：
+
+- spawn 默认 `auto`。
+- auto rename 只改 `name_source === 'auto'` 的 pane。
+- 用户 inline rename、AI rename、keyboard rename 都设置为 `manual`。
+- 如以后需要“恢复自动命名”，再加显式 action。
+
+### 1.4 明确布局状态源
+
+当前 DOM visual order 是事实上的布局源。短期可以保留，但要用 port 包起来：
+
+```typescript
+interface WorkspaceLayoutPort {
+  spawnPane(opts: SpawnPaneOptions): Promise<PaneRef | null>;
+  splitCurrentRow(): Promise<void>;
+  getRows(): WorkspaceRowSnapshot[];
+}
+```
+
+后续再把 row/pane order 迁入结构化 workspace state。
+
+建议未来引入：
+
+```typescript
+type RowId = string;
+
+interface WorkspaceRow {
+  id: RowId;
+  pane_ids: number[];
+  note: string;
+}
+```
+
+这样 snapshot 不再需要从 DOM 反推。
+
+## Phase 2：结构化 workspace state
+
+目标：让 AI 和 UI 都读取同一个结构化状态，而不是依赖 DOM、xterm 文本或手工拼 prompt。
+
+### 2.1 新增 `WorkspaceState.serialize()`
+
+新增：
+
+```text
+src/workspace/WorkspaceState.ts
+```
+
+输出结构建议包含：
+
+- panes。
+- groups。
+- active pane。
+- row/order。
+- cwd。
+- name/group/note。
+- role。
+- status。
+- agent type。
+- last command。
+- last exit code。
+- alternate screen state。
+- foreground process state。
+
+`buildSystemPrompt()` 改成调用 serializer，而不是自己格式化 `sessionManager.getAllPanes()`。
+
+成功标准：
+
+- AI prompt 的 workspace context 由一个 serializer 统一产出。
+- UI 和 AI 不再各自定义不同的 workspace state 表达。
+
+### 2.2 加 OSC 133 command lifecycle
+
+现有 `pty.rs` 已经有 zsh/bash/fish shell hook 和 OSC 7 CWD tracking。下一步应在同一条路径上增加 OSC 133：
+
+- `133;A` prompt start。
+- `133;B` command start。
+- `133;C` command output start。
+- `133;D;<exitcode>` command end。
+
+解析后更新 `PaneInfo`：
+
+```rust
+pub last_command: Option<String>,
+pub last_exit_code: Option<i32>,
+pub alternate_screen: bool,
+```
+
+并补充更明确的运行时状态：
+
+```rust
+pub foreground_process_state: Option<ForegroundProcessState>
+```
+
+成功标准：
+
+- command 完成后能在 `PaneInfo` 里看到 exit code。
+- AI 能区分 idle shell、running command、alternate screen TUI。
+- `status` 不再主要靠前端猜测或手动设置。
+
+### 2.3 新增 AI-friendly pane context API
+
+新增 IPC / workspace API：
+
+```text
+get_pane_context(pane_id)
+```
+
+返回：
+
+- cwd。
+- status。
+- role/group。
+- last command。
+- last exit code。
+- alternate screen。
+- recent output summary 或有限 scrollback 摘要。
+
+这个 API 应通过 `transport` 暴露，不直接在 AI handler 中调用 Tauri。
+
+## Phase 3：规范 Workspace Actions
+
+目标：让 workspace mutation 可记录、可回放、可测试。
+
+### 3.1 使用 discriminated union
+
+把 `{ type: string; [key: string]: unknown }` 升级为严格类型：
+
+```typescript
+export type WorkspaceAction = ...
+export type WorkspaceActionResult = {
+  ok: boolean;
+  message: string;
+  action: WorkspaceAction;
+  error?: string;
+}
+```
+
+### 3.2 加 action log
+
+新增内存 ring buffer：
+
+```typescript
+type ActionLogEntry = {
+  id: string;
+  timestamp: number;
+  source: 'keyboard' | 'ui' | 'ai' | 'system';
+  action: WorkspaceAction;
+  result?: WorkspaceActionResult;
+}
+```
+
+用途：
+
+- 调试 AI 行为。
+- 用户可查看最近 actions。
+- 后续支持 replay / workspace template。
+
+### 3.3 审计直接 mutation
+
+成功标准：
+
+- 没有组件直接调用 `invoke('session_rename')` 或等价 mutation。
+- 没有组件直接 `destroy()` pane 来改变 workspace，除非它只是 action adapter 内部实现。
+- `InputBar` 只负责输入和 UI state，不直接承担 workspace mutation。
+- `WaterfallArea` 只负责布局渲染和 adapter 实现，不是业务决策层。
+
+## Phase 4：重新定义 persistence 边界
+
+目标：避免“keep alive”命名和真实能力不一致。
+
+当前 `persistence.keep_alive` 实际更像：
+
+- app close 时保存 workspace snapshot。
+- next launch 时恢复结构、metadata、cwd。
+
+它不是：
+
+- UI 关闭后 PTY 仍继续运行。
+- tmux-style reattach。
+- daemon runtime。
+
+建议拆成两个概念：
+
+```yaml
+persistence:
+  restore_workspace_on_launch: true
+  save_scrollback_on_exit: true
+
+runtime:
+  detached_runtime: false
+```
+
+短期：
+
+- 保留当前行为。
+- UI 文案不要暗示 PTY 会在窗口关闭后继续运行。
+- snapshot 逻辑继续存在，但不要把它当成 daemon 前置实现。
+
+中期：
+
+- `SessionManager` 可独立 serialize/load。
+- `PtyManager` 继续管理运行时 handle。
+- UI 可从 runtime 读取当前 session state。
+
+长期：
+
+- `SessionManager` 和 `PtyManager` 放进 daemon/runtime process。
+- UI 通过 transport 连接和重连。
+
+## Phase 5：AI 控制面
+
+前面阶段完成后，再发展 AI mode。
+
+AI mode 应该：
+
+- 读取 `WorkspaceState.serialize()`。
+- 生成 `WorkspaceAction[]`。
+- 使用 `PlanQueue` 做确认。
+- 通过 `WorkspaceActions` 执行。
+- 基于 `PaneInfo` / pane context 总结结果。
+
+AI mode 不应该：
+
+- 直接操作 `WaterfallArea`。
+- 直接写 xterm。
+- 依赖 terminal screen scraping 作为主要上下文。
+- 把所有任务都塞进 interactive PTY。
+
+后续可增加多 runtime：
+
+- PTY Runtime：长期交互 session、dev server、REPL、TUI。
+- Task Runtime：一次性命令，例如 `git status`、`npm test`、`cargo check`。
+- Child AI Runtime：未来多 worker / reviewer / researcher。
+
+## 推荐执行顺序
+
+1. 新增 `src/transport.ts`，迁移所有前端 `invoke()` / `listen()`。
+2. 新增 `src/workspace/WorkspaceActions.ts`，用 ports/adapters 包住现有 `WaterfallArea`、`TerminalPane`、`SessionManager`。
+3. 把 `ai-handler.ts` 收缩成 intent parser + LLM client + action dispatcher。
+4. 把 `KeybindingManager`、header、sidebar、InputBar 中的 workspace mutation 逐步迁到 action path。
+5. 把 `plan-executor` 改为 queue。
+6. 从 Rust 和 TypeScript 的 `PaneInfo` 移除 `pty_pid`。
+7. 新增 `SessionObserver`，把 auto-rename / agent sync 从 UI 组件中移出。
+8. 为 pane name 增加 `name_source` 或 `auto_named`。
+9. 新增 `WorkspaceState.serialize()`。
+10. 在 `pty.rs` 的现有 shell hooks 上增加 OSC 133。
+11. 增加 AI-friendly pane context API。
+12. 重新命名和拆分 persistence/runtime 配置。
+13. 最后再做 action log、layout state 正规化、daemon/runtime split。
+
+## 不建议现在做的事
+
+- 不要先做 child AI / 多 agent 编排。
+- 不要新增更多直接 `invoke()` call site。
+- 不要把 `WorkspaceActions` 直接写死依赖 `WaterfallArea`。
+- 不要让 `WaterfallArea` 继续新增业务职责。
+- 不要在 `PaneInfo` 中继续加入 runtime-only 字段。
+- 不要把 terminal screen scraping 作为 AI 上下文主路径。
+- 不要在 plan queue 修复前继续扩大 AI 自动执行能力。
+- 不要把 snapshot restore 误称为真正 keep-alive runtime。
+
+## 验收清单
+
+- 除 `transport.ts` 外，前端没有直接 `invoke()` / `listen()`。
+- `ai-handler.ts` 不 import `WaterfallArea` / `TerminalPane`。
+- `executeAction()` 位于 workspace action module。
+- 键盘、UI、AI 的 workspace mutation 走同一 action path。
+- `PlanExecutor` 支持多个 pending plans。
+- `PaneInfo` 不包含 `pty_pid`。
+- `WaterfallArea` 不调用 `sessionManager.renamePane()`。
+- 自动命名状态可持久化，不只存在前端内存。
+- AI prompt 使用 `WorkspaceState.serialize()`。
+- command lifecycle 和 exit code 能进入结构化 state。
+- persistence 文案和实际能力一致。
+
+## 最小可落地架构
+
+短期不需要重写项目。最小可落地形态是：
+
+```text
+src/
+  transport.ts
+  workspace/
+    WorkspaceActions.ts
+    WorkspaceState.ts
+    ports.ts
+    adapters/
+      WaterfallWorkspaceAdapter.ts
+  session/
+    SessionObserver.ts
+    PaneNamingPolicy.ts
+  ai/
+    ai-handler.ts
+    llm-client.ts
+    plan-queue.ts
+```
+
+Rust 侧短期只需要：
+
+```text
+src-tauri/src/
+  session.rs   # PaneInfo 去掉 pty_pid，增加结构化 metadata
+  pty.rs       # PtyManager 内部保存 runtime handle，增加 OSC 133 parser
+  ipc.rs       # 继续暴露现有 commands，后续增加 pane context API
+```
+
+这条路线能保留当前终端、waterfall、modal input、AI command、settings、snapshot 等现有能力，同时把未来开发的主要风险从“越写越耦合”转为“逐步替换 adapter 内部实现”。

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "fluxtty"
-version = "0.1.1"
+version = "0.1.7"
 dependencies = [
  "crossbeam-channel",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluxtty"
-version = "0.1.7"
+version = "0.1.8"
 description = "Multi-session developer workspace terminal"
 authors = ["fluxtty"]
 license = "MIT"

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
@@ -131,15 +132,70 @@ pub struct WorkspaceAiConfig {
     pub always_confirm_broadcast: bool,
     pub always_confirm_multi_step: bool,
     pub agent_relay_auto_submit: bool,
-    /// Provider: anthropic | openai | google | ollama | claude-cli | none
-    /// If omitted, inferred from the model name.
-    pub provider: Option<String>,
-    /// Model name, e.g. claude-sonnet-4-6, gpt-4o, gemini-2.0-flash, ollama/llama3
+    /// OpenCode-style provider/model id, e.g. anthropic/claude-sonnet-4-5.
     pub model: String,
-    /// Name of the environment variable that holds the API key
+    /// Optional lighter-weight model for future summary/title tasks.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub small_model: Option<String>,
+    /// OpenCode-style provider map keyed by provider id.
+    #[serde(deserialize_with = "deserialize_ai_provider_map")]
+    pub provider: BTreeMap<String, AiProviderConfig>,
+    /// Legacy: name of the environment variable that holds the API key.
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub api_key_env: String,
-    /// Override the API base URL (required for Ollama, useful for custom OpenAI-compatible endpoints)
+    /// Legacy: override API base URL.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct AiProviderConfig {
+    pub name: Option<String>,
+    pub npm: Option<String>,
+    pub options: BTreeMap<String, serde_json::Value>,
+    pub models: BTreeMap<String, AiModelConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct AiModelConfig {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub options: BTreeMap<String, serde_json::Value>,
+    pub variants: BTreeMap<String, AiModelVariantConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct AiModelVariantConfig {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub disabled: bool,
+    pub options: BTreeMap<String, serde_json::Value>,
+}
+
+fn deserialize_ai_provider_map<'de, D>(deserializer: D) -> Result<BTreeMap<String, AiProviderConfig>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+
+    let value = Option::<serde_yaml::Value>::deserialize(deserializer)?;
+    match value {
+        None | Some(serde_yaml::Value::Null) => Ok(BTreeMap::new()),
+        Some(serde_yaml::Value::String(provider_id)) => {
+            let mut providers = BTreeMap::new();
+            if !provider_id.trim().is_empty() {
+                providers.insert(provider_id, AiProviderConfig::default());
+            }
+            Ok(providers)
+        }
+        Some(serde_yaml::Value::Mapping(map)) => {
+            serde_yaml::from_value(serde_yaml::Value::Mapping(map)).map_err(D::Error::custom)
+        }
+        Some(other) => Err(D::Error::custom(format!("workspace_ai.provider must be a provider map, string, or null; got {:?}", other))),
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -158,7 +214,10 @@ pub struct WaterfallConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct PersistenceConfig {
-    pub keep_alive: bool,
+    /// Restore the workspace layout on next launch.
+    /// The legacy YAML key `keep_alive` is still accepted as an alias.
+    #[serde(alias = "keep_alive")]
+    pub restore_workspace_on_launch: bool,
     pub disk_state_path: String,
     pub scrollback_lines: u32,
     pub save_scrollback_on_exit: bool,
@@ -348,9 +407,10 @@ impl Default for WorkspaceAiConfig {
             always_confirm_broadcast: true,
             always_confirm_multi_step: true,
             agent_relay_auto_submit: false,
-            provider: None,
             model: "none".to_string(),
-            api_key_env: "ANTHROPIC_API_KEY".to_string(),
+            small_model: None,
+            provider: BTreeMap::new(),
+            api_key_env: String::new(),
             base_url: None,
         }
     }
@@ -374,7 +434,7 @@ impl Default for WaterfallConfig {
 impl Default for PersistenceConfig {
     fn default() -> Self {
         PersistenceConfig {
-            keep_alive: true,
+            restore_workspace_on_launch: true,
             disk_state_path: "~/.local/share/fluxtty/workspace.json".to_string(),
             scrollback_lines: 5000,
             save_scrollback_on_exit: true,
@@ -432,4 +492,85 @@ pub type SharedConfig = Arc<Mutex<Config>>;
 
 pub fn new_shared_config() -> SharedConfig {
     Arc::new(Mutex::new(load_config()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_opencode_style_workspace_ai_provider_map() {
+        let cfg: Config = serde_yaml::from_str(r#"
+workspace_ai:
+  model: openai/gpt-5
+  small_model: openai/gpt-5-mini
+  provider:
+    openai:
+      options:
+        apiKey: "{env:OPENAI_API_KEY}"
+      models:
+        gpt-5:
+          options:
+            reasoningEffort: high
+"#).unwrap();
+
+        let provider = cfg.workspace_ai.provider.get("openai").unwrap();
+        assert_eq!(cfg.workspace_ai.model, "openai/gpt-5");
+        assert_eq!(cfg.workspace_ai.small_model.as_deref(), Some("openai/gpt-5-mini"));
+        assert_eq!(provider.options.get("apiKey").and_then(|v| v.as_str()), Some("{env:OPENAI_API_KEY}"));
+        assert_eq!(
+            provider.models["gpt-5"].options.get("reasoningEffort").and_then(|v| v.as_str()),
+            Some("high"),
+        );
+    }
+
+    #[test]
+    fn legacy_workspace_ai_provider_string_remains_accepted() {
+        let cfg: Config = serde_yaml::from_str(r#"
+workspace_ai:
+  model: claude-sonnet-4-5
+  provider: anthropic
+  api_key_env: ANTHROPIC_API_KEY
+"#).unwrap();
+
+        assert!(cfg.workspace_ai.provider.contains_key("anthropic"));
+        assert_eq!(cfg.workspace_ai.api_key_env, "ANTHROPIC_API_KEY");
+        assert_eq!(cfg.workspace_ai.model, "claude-sonnet-4-5");
+    }
+
+    #[test]
+    fn workspace_ai_provider_can_be_omitted() {
+        let cfg: Config = serde_yaml::from_str(r#"
+workspace_ai:
+  model: none
+"#).unwrap();
+
+        assert!(cfg.workspace_ai.provider.is_empty());
+        assert_eq!(cfg.workspace_ai.model, "none");
+    }
+
+    #[test]
+    fn persistence_restore_workspace_on_launch_new_key() {
+        let cfg: Config = serde_yaml::from_str(r#"
+persistence:
+  restore_workspace_on_launch: false
+"#).unwrap();
+        assert!(!cfg.persistence.restore_workspace_on_launch);
+    }
+
+    #[test]
+    fn persistence_keep_alive_legacy_alias_accepted() {
+        // Old config files that still use `keep_alive` must continue to work.
+        let cfg: Config = serde_yaml::from_str(r#"
+persistence:
+  keep_alive: false
+"#).unwrap();
+        assert!(!cfg.persistence.restore_workspace_on_launch);
+    }
+
+    #[test]
+    fn persistence_defaults_to_true() {
+        let cfg: Config = serde_yaml::from_str("{}").unwrap();
+        assert!(cfg.persistence.restore_workspace_on_launch);
+    }
 }

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -1,6 +1,6 @@
 use crate::config::{load_config, SharedConfig};
 use crate::pty::SharedPtyManager;
-use crate::session::{AgentType, SessionStatus, SharedSessionManager};
+use crate::session::{AgentType, PaneNameSource, SessionStatus, SharedSessionManager};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, State};
 
@@ -96,7 +96,7 @@ pub async fn pty_spawn(
 
     {
         let mut session = session_mgr.lock().unwrap();
-        let _pane = session.create_pane(args.pane_id, cwd, group, pid, row_index);
+        let _pane = session.create_pane(args.pane_id, cwd, group, row_index);
         // Notify frontend of session change
         let _ = app.emit("session:changed", session.all_panes());
         drop(session);
@@ -172,11 +172,16 @@ pub async fn session_set_active(
 pub async fn session_rename(
     pane_id: u32,
     name: String,
+    name_source: Option<String>,
     app: AppHandle,
     session_mgr: State<'_, SharedSessionManager>,
 ) -> Result<(), String> {
+    let source = match name_source.as_deref() {
+        Some("auto") => PaneNameSource::Auto,
+        _ => PaneNameSource::Manual,
+    };
     let mut session = session_mgr.lock().unwrap();
-    session.rename_pane(pane_id, name);
+    session.rename_pane(pane_id, name, source);
     let _ = app.emit("session:changed", session.all_panes());
     Ok(())
 }
@@ -476,7 +481,10 @@ pub struct LlmCompleteArgs {
     pub model: String,
     pub provider: Option<String>,
     pub api_key_env: Option<String>,
+    pub api_key: Option<String>,
     pub base_url: Option<String>,
+    #[serde(default)]
+    pub options: std::collections::BTreeMap<String, serde_json::Value>,
 }
 
 /// Infer provider from model name (mirrors the JS inferProvider logic).
@@ -496,12 +504,62 @@ fn infer_provider(model: &str) -> &'static str {
 }
 
 /// Strip "provider/" prefix from model name before sending to the API.
-fn strip_provider_prefix(model: &str) -> &str {
+fn strip_provider_prefix<'a>(model: &'a str, provider: &str) -> &'a str {
+    let explicit_prefix = format!("{}/", provider);
+    if let Some(rest) = model.strip_prefix(&explicit_prefix) {
+        return rest;
+    }
+
     let prefixes = ["anthropic/", "openai/", "google/", "ollama/", "ollama:"];
     for p in prefixes {
         if let Some(rest) = model.strip_prefix(p) { return rest; }
     }
     model
+}
+
+fn resolve_config_string(value: &str) -> Result<String, String> {
+    if let Some(name) = value.strip_prefix("{env:").and_then(|v| v.strip_suffix('}')) {
+        return std::env::var(name).map_err(|_| format!("Environment variable '{}' is not set", name));
+    }
+
+    if let Some(path) = value.strip_prefix("{file:").and_then(|v| v.strip_suffix('}')) {
+        let path = if let Some(rest) = path.strip_prefix("~/") {
+            dirs::home_dir().unwrap_or_default().join(rest)
+        } else {
+            std::path::PathBuf::from(path)
+        };
+        return std::fs::read_to_string(&path)
+            .map(|s| s.trim().to_string())
+            .map_err(|e| format!("Could not read {:?}: {}", path, e));
+    }
+
+    Ok(value.to_string())
+}
+
+fn option_string(options: &std::collections::BTreeMap<String, serde_json::Value>, keys: &[&str]) -> Option<String> {
+    keys.iter().find_map(|key| options.get(*key)?.as_str().map(ToString::to_string))
+}
+
+fn option_u64(options: &std::collections::BTreeMap<String, serde_json::Value>, keys: &[&str]) -> Option<u64> {
+    keys.iter().find_map(|key| options.get(*key)?.as_u64())
+}
+
+fn apply_common_llm_options(
+    body: &mut serde_json::Value,
+    options: &std::collections::BTreeMap<String, serde_json::Value>,
+) {
+    if let Some(v) = option_u64(options, &["maxTokens", "max_tokens"]) {
+        body["max_tokens"] = serde_json::json!(v);
+    }
+    if let Some(v) = options.get("temperature").and_then(|v| v.as_f64()) {
+        body["temperature"] = serde_json::json!(v);
+    }
+    if let Some(v) = options.get("topP").or_else(|| options.get("top_p")).and_then(|v| v.as_f64()) {
+        body["top_p"] = serde_json::json!(v);
+    }
+    if let Some(v) = option_string(options, &["reasoningEffort", "reasoning_effort"]) {
+        body["reasoning_effort"] = serde_json::json!(v);
+    }
 }
 
 #[tauri::command]
@@ -512,19 +570,43 @@ pub async fn llm_complete(args: LlmCompleteArgs) -> Result<String, String> {
         .unwrap_or_else(|| infer_provider(&args.model))
         .to_string();
 
-    // Resolve API key from environment variable
-    let api_key = args.api_key_env
+    let base_url = args.base_url
+        .clone()
+        .or_else(|| option_string(&args.options, &["baseURL", "base_url"]))
+        .map(|value| resolve_config_string(&value))
+        .transpose()?;
+
+    // Resolve API key from OpenCode-style {env:...}/{file:...}, or legacy env var.
+    let api_key = args.api_key
         .as_deref()
         .filter(|s| !s.is_empty())
-        .and_then(|env| std::env::var(env).ok())
+        .map(resolve_config_string)
+        .transpose()?
+        .or_else(|| {
+            args.api_key_env
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .and_then(|env| std::env::var(env).ok())
+        })
+        .or_else(|| {
+            option_string(&args.options, &["apiKey", "api_key"])
+                .and_then(|value| resolve_config_string(&value).ok())
+        })
+        .or_else(|| default_api_key_env(&provider).and_then(|env| std::env::var(env).ok()))
         .unwrap_or_default();
 
-    let model = strip_provider_prefix(&args.model).to_string();
+    let model = strip_provider_prefix(&args.model, &provider).to_string();
     let client = reqwest::Client::new();
+    let provider_kind = match provider.as_str() {
+        "anthropic" | "openai" | "google" | "ollama" => provider.as_str(),
+        "openai-compatible" => "openai",
+        _ if base_url.is_some() => "openai",
+        _ => provider.as_str(),
+    };
 
-    match provider.as_str() {
+    match provider_kind {
         "anthropic" => {
-            let base = args.base_url.as_deref().unwrap_or("https://api.anthropic.com");
+            let base = base_url.as_deref().unwrap_or("https://api.anthropic.com");
             let url = format!("{}/v1/messages", base.trim_end_matches('/'));
 
             let system: Vec<_> = args.messages.iter()
@@ -536,13 +618,23 @@ pub async fn llm_complete(args: LlmCompleteArgs) -> Result<String, String> {
                 .map(|m| serde_json::json!({ "role": m.role, "content": m.content }))
                 .collect();
 
+            let max_tokens = option_u64(&args.options, &["maxTokens", "max_tokens"]).unwrap_or(1024);
             let mut body = serde_json::json!({
                 "model": model,
-                "max_tokens": 1024,
+                "max_tokens": max_tokens,
                 "messages": chat,
             });
             if !system.is_empty() {
                 body["system"] = serde_json::json!(system.join("\n\n"));
+            }
+            if let Some(thinking) = args.options.get("thinking") {
+                body["thinking"] = thinking.clone();
+            }
+            if let Some(v) = args.options.get("temperature").and_then(|v| v.as_f64()) {
+                body["temperature"] = serde_json::json!(v);
+            }
+            if let Some(v) = args.options.get("topP").or_else(|| args.options.get("top_p")).and_then(|v| v.as_f64()) {
+                body["top_p"] = serde_json::json!(v);
             }
 
             let res = client.post(&url)
@@ -565,34 +657,36 @@ pub async fn llm_complete(args: LlmCompleteArgs) -> Result<String, String> {
         }
 
         "openai" => {
-            let base = args.base_url.as_deref().unwrap_or("https://api.openai.com");
+            let base = base_url.as_deref().unwrap_or("https://api.openai.com");
             let url = format!("{}/v1/chat/completions", base.trim_end_matches('/'));
 
             let msgs: Vec<_> = args.messages.iter()
                 .map(|m| serde_json::json!({ "role": m.role, "content": m.content }))
                 .collect();
-            let body = serde_json::json!({ "model": model, "messages": msgs });
+            let mut body = serde_json::json!({ "model": model, "messages": msgs });
+            apply_common_llm_options(&mut body, &args.options);
 
-            let res = client.post(&url)
-                .header("Authorization", format!("Bearer {}", api_key))
-                .header("content-type", "application/json")
-                .json(&body)
+            let mut req = client.post(&url).header("content-type", "application/json").json(&body);
+            if !api_key.is_empty() {
+                req = req.header("Authorization", format!("Bearer {}", api_key));
+            }
+            let res = req
                 .send()
                 .await
-                .map_err(|e| format!("OpenAI request failed: {}", e))?;
+                .map_err(|e| format!("OpenAI-compatible request failed: {}", e))?;
 
             if !res.status().is_success() {
                 let status = res.status().as_u16();
                 let text = res.text().await.unwrap_or_default();
-                return Err(format!("OpenAI {}: {}", status, text.trim()));
+                return Err(format!("OpenAI-compatible {}: {}", status, text.trim()));
             }
             let data: serde_json::Value = res.json().await
-                .map_err(|e| format!("OpenAI parse error: {}", e))?;
+                .map_err(|e| format!("OpenAI-compatible parse error: {}", e))?;
             Ok(data["choices"][0]["message"]["content"].as_str().unwrap_or("").to_string())
         }
 
         "google" => {
-            let base = args.base_url.as_deref().unwrap_or("https://generativelanguage.googleapis.com");
+            let base = base_url.as_deref().unwrap_or("https://generativelanguage.googleapis.com");
             let url = format!(
                 "{}/v1beta/models/{}:generateContent",
                 base.trim_end_matches('/'), model
@@ -616,6 +710,12 @@ pub async fn llm_complete(args: LlmCompleteArgs) -> Result<String, String> {
                     "parts": [{ "text": system.join("\n\n") }]
                 });
             }
+            if let Some(max_tokens) = option_u64(&args.options, &["maxTokens", "max_tokens"]) {
+                body["generationConfig"]["maxOutputTokens"] = serde_json::json!(max_tokens);
+            }
+            if let Some(temperature) = args.options.get("temperature").and_then(|v| v.as_f64()) {
+                body["generationConfig"]["temperature"] = serde_json::json!(temperature);
+            }
 
             let res = client.post(&url)
                 .header("Authorization", format!("Bearer {}", api_key))
@@ -637,19 +737,21 @@ pub async fn llm_complete(args: LlmCompleteArgs) -> Result<String, String> {
         }
 
         "ollama" => {
-            let base = args.base_url.as_deref().unwrap_or("http://localhost:11434");
+            let base = base_url.as_deref().unwrap_or("http://localhost:11434");
             let url = format!("{}/api/chat", base.trim_end_matches('/'));
 
-            // Strip leading "ollama/" or "ollama:" if present
             let ollama_model = model.trim_start_matches("ollama/").trim_start_matches("ollama:");
             let msgs: Vec<_> = args.messages.iter()
                 .map(|m| serde_json::json!({ "role": m.role, "content": m.content }))
                 .collect();
-            let body = serde_json::json!({
+            let mut body = serde_json::json!({
                 "model": ollama_model,
                 "messages": msgs,
                 "stream": false,
             });
+            if let Some(options) = args.options.get("options") {
+                body["options"] = options.clone();
+            }
 
             let res = client.post(&url)
                 .header("content-type", "application/json")
@@ -669,10 +771,98 @@ pub async fn llm_complete(args: LlmCompleteArgs) -> Result<String, String> {
         }
 
         other => Err(format!(
-            "Unknown provider \"{}\". Supported: anthropic, openai, google, ollama, claude-cli",
+            "Unknown provider \"{}\". Use anthropic/openai/google/ollama or configure a baseURL for an OpenAI-compatible provider.",
             other
         )),
     }
+}
+
+fn default_api_key_env(provider: &str) -> Option<&'static str> {
+    match provider {
+        "anthropic" => Some("ANTHROPIC_API_KEY"),
+        "openai" => Some("OPENAI_API_KEY"),
+        "google" => Some("GOOGLE_API_KEY"),
+        _ => None,
+    }
+}
+
+/// AI-friendly pane context: structured metadata + recent stripped scrollback.
+/// Returns `None` if the pane does not exist.
+#[derive(Debug, Serialize)]
+pub struct PaneContext {
+    pub info: crate::session::PaneInfo,
+    /// Last N lines of PTY output with ANSI escape codes stripped.
+    pub recent_output: Vec<String>,
+}
+
+/// Maximum lines of scrollback included in pane context.
+const PANE_CONTEXT_OUTPUT_LINES: usize = 50;
+
+#[tauri::command]
+pub async fn get_pane_context(
+    pane_id: u32,
+    pty_mgr: State<'_, SharedPtyManager>,
+    session_mgr: State<'_, SharedSessionManager>,
+) -> Result<Option<PaneContext>, String> {
+    let info = {
+        let session = session_mgr.lock().unwrap();
+        session.all_panes().into_iter().find(|p| p.id == pane_id)
+    };
+    let Some(info) = info else { return Ok(None) };
+
+    let raw_lines = {
+        let pty = pty_mgr.lock().unwrap();
+        pty.get_scrollback(pane_id)
+    };
+
+    // Strip ANSI escape sequences so the AI receives clean text.
+    let recent_output = raw_lines
+        .iter()
+        .rev()
+        .take(PANE_CONTEXT_OUTPUT_LINES)
+        .rev()
+        .map(|line| strip_ansi(line))
+        .filter(|line| !line.trim().is_empty())
+        .collect();
+
+    Ok(Some(PaneContext { info, recent_output }))
+}
+
+/// Very small ANSI stripper: removes ESC-based sequences common in terminal output.
+/// This intentionally avoids pulling in a full-featured crate for a single use-case.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\x1b' {
+            match chars.peek() {
+                // CSI sequence: ESC [ ... final-byte (0x40–0x7E)
+                Some('[') => {
+                    chars.next(); // consume '['
+                    for c in chars.by_ref() {
+                        if ('\x40'..='\x7e').contains(&c) { break; }
+                    }
+                }
+                // OSC sequence: ESC ] ... ST (BEL or ESC \)
+                Some(']') => {
+                    chars.next(); // consume ']'
+                    loop {
+                        match chars.next() {
+                            None | Some('\x07') => break,
+                            Some('\x1b') => { chars.next(); break; } // ESC \
+                            _ => {}
+                        }
+                    }
+                }
+                // Other two-char sequences: skip next char
+                Some(_) => { chars.next(); }
+                None => {}
+            }
+        } else {
+            out.push(ch);
+        }
+    }
+    out
 }
 
 #[tauri::command]
@@ -692,6 +882,8 @@ pub struct PaneSnapshot {
     pub group: String,
     pub note: String,
     pub cwd: String,
+    #[serde(default)]
+    pub name_source: Option<PaneNameSource>,
     pub row_index: usize,
     pub pane_index: usize,
     pub is_active: bool,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -87,6 +87,7 @@ pub fn run() {
             pty_resize,
             pty_kill,
             pty_get_scrollback,
+            get_pane_context,
             session_list,
             session_set_active,
             session_rename,

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -76,20 +76,35 @@ fn setup_zsh() -> ShellIntegration {
     let _ = std::fs::remove_file(zdotdir.join(".zshenv"));
 
     // .zshrc — runs for interactive shells.
-    // precmd_functions/chpwd_functions are plain arrays; appending to them is
-    // zero call-stack overhead.  add-zsh-hook is intentionally avoided because
-    // it is an autoloaded function whose first invocation loads a file from
-    // $fpath, adding depth that can overflow FUNCNEST in heavily-plugined setups.
-    // _wt_cwd is emitted once immediately (before sourcing the user's .zshrc)
-    // so the initial CWD notification fires at the shallowest possible depth.
+    // precmd_functions/chpwd_functions/preexec_functions are plain arrays.
+    // add-zsh-hook is intentionally avoided (can overflow FUNCNEST in heavily
+    // plugined setups).
+    //
+    // OSC 133 shell integration:
+    //   _wt_precmd — runs before each prompt:
+    //     • saves $? so later functions can't clobber it
+    //     • emits OSC 133;D;exitcode (previous command done)
+    //     • emits OSC 7 CWD
+    //     • emits OSC 133;A (prompt start)
+    //   _wt_preexec — runs just before each command executes:
+    //     • emits OSC 133;B;cmd=<command> (command start, first 512 chars)
+    //   chpwd still fires _wt_cwd on plain `cd` between prompts.
     let zshrc = format!(r#"# fluxtty — auto-generated, do not edit
 if [[ -z "$_FLUXTTY_INIT" ]]; then
   export _FLUXTTY_INIT=1
   _wt_cwd() {{ printf '\033]7;file://%s%s\033\\' "$HOST" "$PWD"; }}
-  typeset -ga precmd_functions chpwd_functions
-  precmd_functions+=(_wt_cwd)
+  _wt_precmd() {{
+    local _ec=$?
+    printf '\033]133;D;%d\033\\' "$_ec"
+    _wt_cwd
+    printf '\033]133;A\033\\'
+  }}
+  _wt_preexec() {{ printf '\033]133;B;cmd=%.512s\033\\' "$1"; }}
+  typeset -ga precmd_functions chpwd_functions preexec_functions
+  precmd_functions+=(_wt_precmd)
   chpwd_functions+=(_wt_cwd)
-  _wt_cwd
+  preexec_functions+=(_wt_preexec)
+  _wt_precmd
 fi
 export ZDOTDIR="{orig}"
 [[ -f "{orig}/.zshrc" ]] && source "{orig}/.zshrc"
@@ -113,11 +128,33 @@ fn setup_bash(user_args: &[String]) -> ShellIntegration {
     }
 
     let init_path = init_dir.join("bash-init.sh");
+    // OSC 133 shell integration for bash:
+    //   _wt_precmd_bash — runs via PROMPT_COMMAND before each prompt:
+    //     captures $?, emits OSC 133;D, OSC 7 CWD, OSC 133;A.
+    //   DEBUG trap — runs before each command to emit OSC 133;B.
+    //     Uses $_wt_cmd_pending flag to emit only the first expansion per
+    //     interactive command (the DEBUG trap fires for every pipeline stage,
+    //     so we guard with a flag cleared in PROMPT_COMMAND).
     let init_script = r#"# fluxtty — auto-generated, do not edit
 if [[ -z "$_FLUXTTY_INIT" ]]; then
   export _FLUXTTY_INIT=1
   _wt_cwd() { printf '\033]7;file://%s%s\007' "${HOSTNAME:-$(hostname)}" "$PWD"; }
-  _wt_cwd
+  _wt_precmd_bash() {
+    local _ec=$?
+    printf '\033]133;D;%d\007' "$_ec"
+    _wt_cwd
+    printf '\033]133;A\007'
+    _wt_cmd_pending=1
+  }
+  _wt_preexec_bash() {
+    if [[ "$_wt_cmd_pending" == "1" && "$BASH_COMMAND" != "_wt_precmd_bash" ]]; then
+      _wt_cmd_pending=0
+      printf '\033]133;B;cmd=%.512s\007' "$BASH_COMMAND"
+    fi
+  }
+  _wt_cmd_pending=1
+  trap '_wt_preexec_bash' DEBUG
+  _wt_precmd_bash
 fi
 if shopt -q login_shell 2>/dev/null; then
   for _f in ~/.bash_profile ~/.bash_login ~/.profile; do
@@ -127,10 +164,11 @@ if shopt -q login_shell 2>/dev/null; then
 else
   [[ -f ~/.bashrc ]] && source ~/.bashrc
 fi
-# Re-attach hook in case rc files overwrote PROMPT_COMMAND
-if [[ "$PROMPT_COMMAND" != *_wt_cwd* ]]; then
-  PROMPT_COMMAND="_wt_cwd${PROMPT_COMMAND:+; $PROMPT_COMMAND}"
+# Re-attach hooks in case rc files overwrote PROMPT_COMMAND / DEBUG trap
+if [[ "$PROMPT_COMMAND" != *_wt_precmd_bash* ]]; then
+  PROMPT_COMMAND="_wt_precmd_bash${PROMPT_COMMAND:+; $PROMPT_COMMAND}"
 fi
+trap '_wt_preexec_bash' DEBUG
 "#;
     let _ = std::fs::write(&init_path, init_script);
 
@@ -170,18 +208,117 @@ fn setup_fish() -> ShellIntegration {
     if std::fs::create_dir_all(&conf_d).is_err() {
         return ShellIntegration::default();
     }
+    // fish auto-sources every *.fish file in conf.d at startup — idempotent.
+    // OSC 133 integration:
+    //   fish_prompt event → OSC 133;D (exit code of last cmd), OSC 7, OSC 133;A
+    //   fish_preexec event → OSC 133;B;cmd=<command>
     let script = r#"# fluxtty — auto-generated, do not edit
 if not set -q _FLUXTTY_INIT
   set -gx _FLUXTTY_INIT 1
-  function _wt_cwd_prompt --on-event fish_prompt
+  function _wt_precmd_fish --on-event fish_prompt
+    printf '\033]133;D;%d\033\\' $status
     printf '\033]7;file://%s%s\033\\' (hostname) $PWD
+    printf '\033]133;A\033\\'
   end
-  _wt_cwd_prompt
+  function _wt_preexec_fish --on-event fish_preexec
+    printf '\033]133;B;cmd=%.512s\033\\' $argv[1]
+  end
+  _wt_precmd_fish
 end
 "#;
     let _ = std::fs::write(conf_d.join("fluxtty.fish"), script);
     ShellIntegration::default()
 }
+
+// ── OSC 133 shell integration parser ────────────────────────────────────────
+
+/// Events decoded from OSC 133 sequences emitted by the shell integration hooks.
+#[derive(Debug, PartialEq)]
+pub enum Osc133Event {
+    /// 133;A — prompt is about to be drawn.
+    PromptStart,
+    /// 133;B[;cmd=<text>] — a command is about to execute.
+    CommandStart { cmd: Option<String> },
+    /// 133;C — command output is about to begin (rarely used; kept for completeness).
+    CommandOutput,
+    /// 133;D;exitcode — command finished with the given exit code.
+    CommandDone { exit_code: i32 },
+}
+
+/// Parse all OSC 133 sequences present in `data`.
+/// Handles both BEL (0x07) and ST (ESC \) terminators.
+pub fn parse_osc133(data: &str) -> Vec<Osc133Event> {
+    let prefix = "\x1b]133;";
+    let mut events = Vec::new();
+    let mut search = data;
+
+    while let Some(rel) = search.find(prefix) {
+        search = &search[rel + prefix.len()..];
+
+        // Find terminator — take whichever comes first.
+        let end_bel = search.find('\x07');
+        let end_st  = search.find("\x1b\\");
+        let end = match (end_bel, end_st) {
+            (Some(a), Some(b)) => a.min(b),
+            (Some(a), None)    => a,
+            (None,    Some(b)) => b,
+            (None,    None)    => search.len(),
+        };
+
+        let seq = &search[..end];
+        if let Some(ev) = parse_one_osc133(seq) {
+            events.push(ev);
+        }
+
+        // Advance past the terminator.
+        if end < search.len() {
+            let term_len = if search[end..].starts_with("\x1b\\") { 2 } else { 1 };
+            search = &search[end + term_len..];
+        } else {
+            break;
+        }
+    }
+
+    events
+}
+
+fn parse_one_osc133(seq: &str) -> Option<Osc133Event> {
+    let first = seq.chars().next()?;
+    match first {
+        'A' => Some(Osc133Event::PromptStart),
+        'B' => {
+            // Optional suffix: ;cmd=<text>
+            let cmd = seq.strip_prefix("B;cmd=").map(|s| s.to_string());
+            Some(Osc133Event::CommandStart { cmd })
+        }
+        'C' => Some(Osc133Event::CommandOutput),
+        'D' => {
+            let code_str = seq.strip_prefix("D;").unwrap_or("0");
+            let exit_code = code_str.parse::<i32>().unwrap_or(0);
+            Some(Osc133Event::CommandDone { exit_code })
+        }
+        _ => None,
+    }
+}
+
+// ── Alternate-screen detection ───────────────────────────────────────────────
+
+/// Returns `Some(true)` if the data chunk enters alternate screen,
+/// `Some(false)` if it exits, `None` if neither sequence is present.
+pub fn parse_alternate_screen(data: &str) -> Option<bool> {
+    // Scan once for both markers; take the last occurrence to handle the rare
+    // case where a single chunk contains both enter and exit.
+    let enter = data.rfind("\x1b[?1049h");
+    let exit  = data.rfind("\x1b[?1049l");
+    match (enter, exit) {
+        (Some(a), Some(b)) => Some(a > b), // whichever is later wins
+        (Some(_), None)    => Some(true),
+        (None,    Some(_)) => Some(false),
+        (None,    None)    => None,
+    }
+}
+
+// ── OSC 7 ────────────────────────────────────────────────────────────────────
 
 /// Parse an OSC 7 sequence from a PTY data chunk.
 /// Format: ESC ] 7 ; file://hostname/path ST  (ST = BEL or ESC \)
@@ -332,12 +469,46 @@ impl PtyManager {
                             }
                         }
 
-                        // Parse OSC 7 → update session CWD
-                        if let Some(new_cwd) = parse_osc7(&data_str) {
-                            if let Ok(mut session) = session_mgr.lock() {
-                                session.set_pane_cwd(pane_id, new_cwd);
-                                let all = session.all_panes();
-                                let _ = app.emit("session:changed", all);
+                        // Parse all escape-sequence metadata before acquiring
+                        // the session lock so we hold the lock as briefly as possible.
+                        let new_cwd       = parse_osc7(&data_str);
+                        let osc133_events = parse_osc133(&data_str);
+                        let alt_screen    = parse_alternate_screen(&data_str);
+
+                        let state_changed = new_cwd.is_some()
+                            || !osc133_events.is_empty()
+                            || alt_screen.is_some();
+
+                        if state_changed {
+                            let all_panes = if let Ok(mut session) = session_mgr.lock() {
+                                if let Some(cwd) = new_cwd {
+                                    session.set_pane_cwd(pane_id, cwd);
+                                }
+                                for event in osc133_events {
+                                    match event {
+                                        Osc133Event::CommandStart { cmd } => {
+                                            if let Some(cmd_text) = cmd {
+                                                let trimmed = cmd_text.trim().to_string();
+                                                if !trimmed.is_empty() {
+                                                    session.set_pane_last_command(pane_id, trimmed);
+                                                }
+                                            }
+                                        }
+                                        Osc133Event::CommandDone { exit_code } => {
+                                            session.set_pane_command_done(pane_id, exit_code);
+                                        }
+                                        _ => {}
+                                    }
+                                }
+                                if let Some(active) = alt_screen {
+                                    session.set_pane_alternate_screen(pane_id, active);
+                                }
+                                session.all_panes()
+                            } else {
+                                vec![]
+                            };
+                            if !all_panes.is_empty() {
+                                let _ = app.emit("session:changed", all_panes);
                             }
                         }
 
@@ -405,4 +576,153 @@ pub type SharedPtyManager = Arc<Mutex<PtyManager>>;
 
 pub fn new_shared_pty_manager(max_scrollback: usize) -> SharedPtyManager {
     Arc::new(Mutex::new(PtyManager::new(max_scrollback)))
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── parse_osc133 ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_osc133_prompt_start_bel() {
+        let data = "\x1b]133;A\x07";
+        let events = parse_osc133(data);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], Osc133Event::PromptStart));
+    }
+
+    #[test]
+    fn test_osc133_prompt_start_st() {
+        let data = "\x1b]133;A\x1b\\";
+        let events = parse_osc133(data);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], Osc133Event::PromptStart));
+    }
+
+    #[test]
+    fn test_osc133_command_start_no_cmd() {
+        let data = "\x1b]133;B\x07";
+        let events = parse_osc133(data);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            Osc133Event::CommandStart { cmd } => assert!(cmd.is_none()),
+            _ => panic!("expected CommandStart"),
+        }
+    }
+
+    #[test]
+    fn test_osc133_command_start_with_cmd() {
+        let data = "\x1b]133;B;cmd=cargo build\x07";
+        let events = parse_osc133(data);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            Osc133Event::CommandStart { cmd } => {
+                assert_eq!(cmd.as_deref(), Some("cargo build"));
+            }
+            _ => panic!("expected CommandStart"),
+        }
+    }
+
+    #[test]
+    fn test_osc133_command_done_zero() {
+        let data = "\x1b]133;D;0\x07";
+        let events = parse_osc133(data);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], Osc133Event::CommandDone { exit_code: 0 }));
+    }
+
+    #[test]
+    fn test_osc133_command_done_nonzero() {
+        let data = "\x1b]133;D;127\x07";
+        let events = parse_osc133(data);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], Osc133Event::CommandDone { exit_code: 127 }));
+    }
+
+    #[test]
+    fn test_osc133_multiple_events_in_one_chunk() {
+        // Simulate a chunk that contains D (done) then A (prompt start) then the prompt text.
+        let data = "some output\x1b]133;D;0\x07\x1b]133;A\x07$ ";
+        let events = parse_osc133(data);
+        assert_eq!(events.len(), 2);
+        assert!(matches!(events[0], Osc133Event::CommandDone { exit_code: 0 }));
+        assert!(matches!(events[1], Osc133Event::PromptStart));
+    }
+
+    #[test]
+    fn test_osc133_embedded_in_normal_output() {
+        let data = "normal text\x1b]133;B;cmd=git status\x1b\\more text";
+        let events = parse_osc133(data);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            Osc133Event::CommandStart { cmd } => {
+                assert_eq!(cmd.as_deref(), Some("git status"));
+            }
+            _ => panic!("expected CommandStart"),
+        }
+    }
+
+    #[test]
+    fn test_osc133_no_sequences() {
+        let data = "hello world\r\n$ ";
+        let events = parse_osc133(data);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_osc133_unknown_command_ignored() {
+        let data = "\x1b]133;Z\x07";
+        let events = parse_osc133(data);
+        assert!(events.is_empty());
+    }
+
+    // ── parse_alternate_screen ────────────────────────────────────────────────
+
+    #[test]
+    fn test_alt_screen_enter() {
+        let data = "\x1b[?1049h";
+        assert_eq!(parse_alternate_screen(data), Some(true));
+    }
+
+    #[test]
+    fn test_alt_screen_exit() {
+        let data = "\x1b[?1049l";
+        assert_eq!(parse_alternate_screen(data), Some(false));
+    }
+
+    #[test]
+    fn test_alt_screen_none() {
+        let data = "no escape sequences here";
+        assert_eq!(parse_alternate_screen(data), None);
+    }
+
+    #[test]
+    fn test_alt_screen_exit_after_enter_in_same_chunk() {
+        // Enter then exit in same chunk → exit (last one) wins.
+        let data = "\x1b[?1049h some output \x1b[?1049l";
+        assert_eq!(parse_alternate_screen(data), Some(false));
+    }
+
+    #[test]
+    fn test_alt_screen_enter_after_exit_in_same_chunk() {
+        let data = "\x1b[?1049l then \x1b[?1049h";
+        assert_eq!(parse_alternate_screen(data), Some(true));
+    }
+
+    // ── parse_osc7 ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_osc7_bel() {
+        let data = "\x1b]7;file://myhostname/Users/alice/projects\x07";
+        assert_eq!(parse_osc7(data), Some("/Users/alice/projects".to_string()));
+    }
+
+    #[test]
+    fn test_osc7_st() {
+        let data = "\x1b]7;file://myhostname/home/bob/src\x1b\\";
+        assert_eq!(parse_osc7(data), Some("/home/bob/src".to_string()));
+    }
 }

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -496,6 +496,8 @@ impl PtyManager {
                                         }
                                         Osc133Event::CommandDone { exit_code } => {
                                             session.set_pane_command_done(pane_id, exit_code);
+                                            let _ = app.emit("pane:command_complete",
+                                                serde_json::json!({ "pane_id": pane_id, "exit_code": exit_code }));
                                         }
                                         _ => {}
                                     }

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -20,6 +20,18 @@ pub enum AgentType {
     Unknown,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum PaneNameSource {
+    Auto,
+    Manual,
+}
+
+impl Default for PaneNameSource {
+    fn default() -> Self {
+        PaneNameSource::Auto
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PaneInfo {
@@ -29,10 +41,16 @@ pub struct PaneInfo {
     pub note: String,
     pub status: SessionStatus,
     pub cwd: String,
-    pub pty_pid: u32,
+    pub name_source: PaneNameSource,
     pub agent_type: AgentType,
     pub row_index: usize,
     pub pane_index: usize,
+    /// Last command submitted to the shell (captured via OSC 133;B).
+    pub last_command: Option<String>,
+    /// Exit code of the last completed command (captured via OSC 133;D).
+    pub last_exit_code: Option<i32>,
+    /// Whether the pane is currently in alternate screen mode (e.g. vim, htop).
+    pub alternate_screen: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -66,7 +84,7 @@ impl SessionManager {
         }
     }
 
-    pub fn create_pane(&mut self, id: u32, cwd: String, group: String, pty_pid: u32, row_index: usize) -> PaneInfo {
+    pub fn create_pane(&mut self, id: u32, cwd: String, group: String, row_index: usize) -> PaneInfo {
         // Keep next_id ahead of any explicitly-assigned id to avoid future collisions
         if id >= self.next_id {
             self.next_id = id + 1;
@@ -87,10 +105,13 @@ impl SessionManager {
             note: String::new(),
             status: SessionStatus::Idle,
             cwd,
-            pty_pid,
+            name_source: PaneNameSource::Auto,
             agent_type: AgentType::None,
             row_index,
             pane_index,
+            last_command: None,
+            last_exit_code: None,
+            alternate_screen: false,
         };
 
         // Add to layout
@@ -142,9 +163,10 @@ impl SessionManager {
         self.layout.active_pane_id
     }
 
-    pub fn rename_pane(&mut self, id: u32, name: String) {
+    pub fn rename_pane(&mut self, id: u32, name: String, name_source: PaneNameSource) {
         if let Some(pane) = self.panes.get_mut(&id) {
             pane.name = name;
+            pane.name_source = name_source;
         }
     }
 
@@ -175,6 +197,30 @@ impl SessionManager {
     pub fn set_pane_note(&mut self, id: u32, note: String) {
         if let Some(pane) = self.panes.get_mut(&id) {
             pane.note = note;
+        }
+    }
+
+    pub fn set_pane_last_command(&mut self, id: u32, cmd: String) {
+        if let Some(pane) = self.panes.get_mut(&id) {
+            pane.last_command = Some(cmd);
+            pane.status = SessionStatus::Running;
+        }
+    }
+
+    pub fn set_pane_command_done(&mut self, id: u32, exit_code: i32) {
+        if let Some(pane) = self.panes.get_mut(&id) {
+            pane.last_exit_code = Some(exit_code);
+            pane.status = if exit_code == 0 {
+                SessionStatus::Idle
+            } else {
+                SessionStatus::Error
+            };
+        }
+    }
+
+    pub fn set_pane_alternate_screen(&mut self, id: u32, active: bool) {
+        if let Some(pane) = self.panes.get_mut(&id) {
+            pane.alternate_screen = active;
         }
     }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "fluxtty",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "identifier": "dev.fluxtty.app",
   "build": {
     "devUrl": "http://localhost:1420",

--- a/src/__mocks__/tauri-core.ts
+++ b/src/__mocks__/tauri-core.ts
@@ -1,0 +1,5 @@
+// Stub for @tauri-apps/api/core used in tests.
+// Individual tests override transport.send via vi.mock('../transport').
+export function invoke(_cmd: string, _args?: unknown): Promise<unknown> {
+  return Promise.resolve(undefined);
+}

--- a/src/__mocks__/tauri-event.ts
+++ b/src/__mocks__/tauri-event.ts
@@ -1,0 +1,10 @@
+// Stub for @tauri-apps/api/event used in tests.
+// Individual tests override transport.listen via vi.mock('../transport').
+export type UnlistenFn = () => void;
+
+export function listen<T>(
+  _event: string,
+  _handler: (payload: T) => void,
+): Promise<UnlistenFn> {
+  return Promise.resolve(() => {});
+}

--- a/src/__tests__/WorkspaceActions.test.ts
+++ b/src/__tests__/WorkspaceActions.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Transport mock (needed by waitForCommand transitively) ────────────────────
+type PayloadHandler = (payload: unknown) => void;
+const registeredListeners = new Map<string, PayloadHandler[]>();
+
+vi.mock('../transport', () => ({
+  transport: {
+    send: vi.fn().mockResolvedValue(null),
+    listen: vi.fn().mockImplementation((event: string, handler: PayloadHandler) => {
+      if (!registeredListeners.has(event)) registeredListeners.set(event, []);
+      registeredListeners.get(event)!.push(handler);
+      return Promise.resolve(() => {
+        const arr = registeredListeners.get(event) ?? [];
+        const idx = arr.indexOf(handler);
+        if (idx >= 0) arr.splice(idx, 1);
+      });
+    }),
+  },
+}));
+
+function emitCommandComplete(paneId: number, exitCode: number) {
+  for (const handler of registeredListeners.get('pane:command_complete') ?? []) {
+    handler({ pane_id: paneId, exit_code: exitCode });
+  }
+}
+
+// ── WorkspaceState mock (for `read` action) ───────────────────────────────────
+vi.mock('../workspace/WorkspaceState', () => ({
+  getPaneContext: vi.fn().mockResolvedValue({
+    info: {},
+    recent_output: ['line 1', 'line 2', 'error: something failed'],
+  }),
+  formatWorkspaceContext: vi.fn().mockReturnValue('(mock context)'),
+  serializeWorkspaceState: vi.fn().mockReturnValue({ panes: [], active_pane_id: null, rows: [] }),
+  setWorkspaceLayoutReader: vi.fn(),
+}));
+
+import { workspaceActions, type WorkspaceActionPorts } from '../workspace/WorkspaceActions';
+import type { PaneInfo } from '../session/types';
+
+// ── Shared test helpers ───────────────────────────────────────────────────────
+
+function makePane(overrides: Partial<PaneInfo> = {}): PaneInfo {
+  return {
+    id: 1,
+    name: 'frontend',
+    group: 'default',
+    note: '',
+    status: 'idle',
+    cwd: '/app',
+    name_source: 'auto',
+    agent_type: 'none',
+    row_index: 0,
+    pane_index: 0,
+    last_command: null,
+    last_exit_code: null,
+    alternate_screen: false,
+    ...overrides,
+  };
+}
+
+function makePorts(panes: PaneInfo[]): WorkspaceActionPorts {
+  const writes: Array<[number, string]> = [];
+  return {
+    session: {
+      getAllPanes: () => panes,
+      getPane: (id) => panes.find(p => p.id === id),
+      getActivePaneId: () => null,
+      getActivePane: () => undefined,
+      setActivePane: vi.fn().mockResolvedValue(undefined),
+      renamePane: vi.fn().mockResolvedValue(undefined),
+      setPaneGroup: vi.fn().mockResolvedValue(undefined),
+      setPaneAgent: vi.fn().mockResolvedValue(undefined),
+      setPaneStatus: vi.fn().mockResolvedValue(undefined),
+      setPaneNote: vi.fn().mockResolvedValue(undefined),
+    },
+    terminal: {
+      write: vi.fn().mockImplementation((paneId: number, data: string) => {
+        writes.push([paneId, data]);
+        return Promise.resolve();
+      }),
+    },
+    layout: {
+      spawnPane: vi.fn().mockResolvedValue({ paneId: 99 }),
+      splitCurrentRow: vi.fn().mockResolvedValue(undefined),
+      closePane: vi.fn().mockResolvedValue(undefined),
+    },
+    viewport: {
+      scrollToPane: vi.fn(),
+    },
+    _writes: writes,
+  } as unknown as WorkspaceActionPorts & { _writes: Array<[number, string]> };
+}
+
+beforeEach(() => {
+  registeredListeners.clear();
+});
+
+// ── run-await ─────────────────────────────────────────────────────────────────
+
+describe('run-await action', () => {
+  it('writes the command and resolves ok on exit 0', async () => {
+    const pane = makePane({ id: 1, name: 'frontend' });
+    const ports = makePorts([pane]);
+    workspaceActions.configure(ports);
+
+    const promise = workspaceActions.dispatch({ type: 'run-await', target: 'frontend', cmd: 'npm test' });
+    await vi.waitFor(() => registeredListeners.has('pane:command_complete'));
+    emitCommandComplete(1, 0);
+
+    const result = await promise;
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain('exit 0');
+  });
+
+  it('resolves not-ok on non-zero exit code', async () => {
+    const pane = makePane({ id: 2, name: 'backend' });
+    const ports = makePorts([pane]);
+    workspaceActions.configure(ports);
+
+    const promise = workspaceActions.dispatch({ type: 'run-await', target: 'backend', cmd: 'cargo test' });
+    await vi.waitFor(() => registeredListeners.has('pane:command_complete'));
+    emitCommandComplete(2, 1);
+
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('exit 1');
+  });
+
+  it('fails when session is not found', async () => {
+    workspaceActions.configure(makePorts([]));
+    const result = await workspaceActions.dispatch({ type: 'run-await', target: 'missing', cmd: 'ls' });
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('not found');
+  });
+
+  it('rejects on timeout', async () => {
+    const pane = makePane({ id: 3, name: 'frontend' });
+    workspaceActions.configure(makePorts([pane]));
+    const result = await workspaceActions.dispatch({ type: 'run-await', target: 'frontend', cmd: 'sleep 99', timeout_ms: 50 });
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('Timeout');
+  });
+});
+
+// ── read ──────────────────────────────────────────────────────────────────────
+
+describe('read action', () => {
+  it('returns pane output from getPaneContext', async () => {
+    const pane = makePane({ id: 1, last_command: 'npm test', last_exit_code: 1 });
+    workspaceActions.configure(makePorts([pane]));
+
+    const result = await workspaceActions.dispatch({ type: 'read', target: 'frontend' });
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain('Last command: npm test');
+    expect(result.message).toContain('Exit code: 1');
+    expect(result.message).toContain('line 1');
+    expect(result.message).toContain('error: something failed');
+  });
+
+  it('fails when session is not found', async () => {
+    workspaceActions.configure(makePorts([]));
+    const result = await workspaceActions.dispatch({ type: 'read', target: 'nope' });
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ── pipeline ──────────────────────────────────────────────────────────────────
+
+describe('pipeline action', () => {
+  it('runs a single-step pipeline and returns summary', async () => {
+    const pane = makePane({ id: 1, name: 'frontend' });
+    workspaceActions.configure(makePorts([pane]));
+
+    const promise = workspaceActions.dispatch({
+      type: 'pipeline',
+      label: 'Build',
+      steps: [{ label: 'compile', actions: [{ target: 'frontend', cmd: 'npm run build' }] }],
+    });
+
+    await vi.waitFor(() => registeredListeners.has('pane:command_complete'));
+    emitCommandComplete(1, 0);
+
+    const result = await promise;
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain('compile');
+    expect(result.message).toContain('exit 0');
+  });
+
+  it('stops at prev-success when first step fails', async () => {
+    const pane = makePane({ id: 1, name: 'frontend' });
+    workspaceActions.configure(makePorts([pane]));
+
+    const promise = workspaceActions.dispatch({
+      type: 'pipeline',
+      steps: [
+        { label: 'build', actions: [{ target: 'frontend', cmd: 'npm run build' }] },
+        { label: 'deploy', condition: 'prev-success', actions: [{ target: 'frontend', cmd: './deploy.sh' }] },
+      ],
+    });
+
+    await vi.waitFor(() => registeredListeners.has('pane:command_complete'));
+    emitCommandComplete(1, 1); // build fails
+
+    const result = await promise;
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain('Stopped before "deploy"');
+  });
+
+  it('runs parallel step actions simultaneously', async () => {
+    const pane1 = makePane({ id: 1, name: 'frontend' });
+    const pane2 = makePane({ id: 2, name: 'backend' });
+    workspaceActions.configure(makePorts([pane1, pane2]));
+
+    const starts: number[] = [];
+    const originalDispatch = workspaceActions.dispatch.bind(workspaceActions);
+    vi.spyOn(workspaceActions, 'dispatch').mockImplementation(async (action) => {
+      if (action.type === 'run-await') starts.push(Date.now());
+      return originalDispatch(action);
+    });
+
+    const promise = workspaceActions.dispatch({
+      type: 'pipeline',
+      steps: [
+        {
+          parallel: true,
+          actions: [
+            { target: 'frontend', cmd: 'npm test' },
+            { target: 'backend', cmd: 'cargo test' },
+          ],
+        },
+      ],
+    });
+
+    await vi.waitFor(() => (registeredListeners.get('pane:command_complete') ?? []).length >= 2);
+    emitCommandComplete(1, 0);
+    emitCommandComplete(2, 0);
+
+    const result = await promise;
+    expect(result.ok).toBe(true);
+    vi.restoreAllMocks();
+  });
+
+  it('skips step when condition is prev-fail but previous succeeded', async () => {
+    const pane = makePane({ id: 1, name: 'frontend' });
+    workspaceActions.configure(makePorts([pane]));
+
+    const promise = workspaceActions.dispatch({
+      type: 'pipeline',
+      steps: [
+        { label: 'build', actions: [{ target: 'frontend', cmd: 'npm run build' }] },
+        { label: 'rollback', condition: 'prev-fail', actions: [{ target: 'frontend', cmd: './rollback.sh' }] },
+      ],
+    });
+
+    await vi.waitFor(() => registeredListeners.has('pane:command_complete'));
+    emitCommandComplete(1, 0); // build succeeds
+
+    const result = await promise;
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain('Skipped "rollback"');
+  });
+
+  it('sequential step actions run one at a time', async () => {
+    const pane = makePane({ id: 1, name: 'ops' });
+    workspaceActions.configure(makePorts([pane]));
+
+    const completionOrder: number[] = [];
+
+    const promise = workspaceActions.dispatch({
+      type: 'pipeline',
+      steps: [
+        {
+          parallel: false,
+          actions: [
+            { target: 'ops', cmd: 'step1' },
+            { target: 'ops', cmd: 'step2' },
+          ],
+        },
+      ],
+    });
+
+    // Wait for step1's listener, then complete it.
+    await vi.waitFor(() => (registeredListeners.get('pane:command_complete') ?? []).length >= 1);
+    completionOrder.push(1);
+    emitCommandComplete(1, 0); // step1 done
+
+    // A setTimeout(0) drains all pending microtasks (step1 resolution → pipeline
+    // loop → step2 execute → transport.listen) before we emit step2's completion,
+    // avoiding a race where step2's listener isn't registered yet.
+    await new Promise(r => setTimeout(r, 0));
+    completionOrder.push(2);
+    emitCommandComplete(1, 0); // step2 done
+
+    const result = await promise;
+    expect(result.ok).toBe(true);
+    expect(completionOrder).toEqual([1, 2]);
+  });
+});
+
+// ── actionDescription ─────────────────────────────────────────────────────────
+
+describe('actionDescription', () => {
+  it('describes run-await', () => {
+    const desc = workspaceActions.actionDescription({ type: 'run-await', target: 'frontend', cmd: 'npm test' });
+    expect(desc).toContain('await completion');
+    expect(desc).toContain('npm test');
+  });
+
+  it('describes read', () => {
+    const desc = workspaceActions.actionDescription({ type: 'read', target: 'backend' });
+    expect(desc).toContain('read output');
+    expect(desc).toContain('backend');
+  });
+
+  it('describes pipeline with steps', () => {
+    const desc = workspaceActions.actionDescription({
+      type: 'pipeline',
+      label: 'CI',
+      steps: [
+        { label: 'build', actions: [{ target: 'frontend', cmd: 'npm build' }] },
+        { label: 'test', condition: 'prev-success', actions: [{ target: 'test', cmd: 'npm test' }] },
+      ],
+    });
+    expect(desc).toContain('CI');
+    expect(desc).toContain('build');
+    expect(desc).toContain('test');
+    expect(desc).toContain('[if prev-success]');
+  });
+});

--- a/src/__tests__/WorkspaceActions.test.ts
+++ b/src/__tests__/WorkspaceActions.test.ts
@@ -65,7 +65,7 @@ function makePorts(panes: PaneInfo[]): WorkspaceActionPorts {
   return {
     session: {
       getAllPanes: () => panes,
-      getPane: (id) => panes.find(p => p.id === id),
+      getPane: (id: number) => panes.find(p => p.id === id),
       getActivePaneId: () => null,
       getActivePane: () => undefined,
       setActivePane: vi.fn().mockResolvedValue(undefined),

--- a/src/__tests__/WorkspaceState.test.ts
+++ b/src/__tests__/WorkspaceState.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { formatWorkspaceContext } from '../workspace/WorkspaceState';
+import type { SerializedWorkspaceState } from '../workspace/WorkspaceState';
+import type { PaneInfo } from '../session/types';
+
+function makePane(overrides: Partial<PaneInfo> = {}): PaneInfo {
+  return {
+    id: 1,
+    name: 'test',
+    group: 'default',
+    note: '',
+    status: 'idle',
+    cwd: '/home/user',
+    name_source: 'auto',
+    agent_type: 'none',
+    row_index: 0,
+    pane_index: 0,
+    last_command: null,
+    last_exit_code: null,
+    alternate_screen: false,
+    ...overrides,
+  };
+}
+
+function makeState(panes: PaneInfo[], activePaneId: number | null = null): SerializedWorkspaceState {
+  return {
+    panes,
+    active_pane_id: activePaneId,
+    rows: [{ index: 0, note: '', pane_ids: panes.map(p => p.id) }],
+  };
+}
+
+describe('formatWorkspaceContext', () => {
+  it('marks the active pane', () => {
+    const pane = makePane({ id: 1, name: 'frontend' });
+    const result = formatWorkspaceContext(makeState([pane], 1));
+    expect(result).toContain('<- ACTIVE');
+  });
+
+  it('does not mark inactive panes as active', () => {
+    const pane = makePane({ id: 2, name: 'backend' });
+    const result = formatWorkspaceContext(makeState([pane], 1));
+    expect(result).not.toContain('<- ACTIVE');
+  });
+
+  it('highlights non-zero exit codes with warning symbol', () => {
+    const pane = makePane({ last_exit_code: 1 });
+    const result = formatWorkspaceContext(makeState([pane]));
+    expect(result).toContain('exit:1⚠');
+  });
+
+  it('shows exit:0 without warning symbol for success', () => {
+    const pane = makePane({ last_exit_code: 0 });
+    const result = formatWorkspaceContext(makeState([pane]));
+    expect(result).toContain('exit:0');
+    expect(result).not.toContain('⚠');
+  });
+
+  it('marks running panes as [RUNNING]', () => {
+    const pane = makePane({ status: 'running' });
+    const result = formatWorkspaceContext(makeState([pane]));
+    expect(result).toContain('[RUNNING]');
+  });
+
+  it('marks alternate-screen panes as TUI:no-shell', () => {
+    const pane = makePane({ alternate_screen: true });
+    const result = formatWorkspaceContext(makeState([pane]));
+    expect(result).toContain('[TUI:no-shell]');
+  });
+
+  it('shows last command in quotes', () => {
+    const pane = makePane({ last_command: 'npm test' });
+    const result = formatWorkspaceContext(makeState([pane]));
+    expect(result).toContain('last:"npm test"');
+  });
+
+  it('shows agent type when set', () => {
+    const pane = makePane({ agent_type: 'claude' });
+    const result = formatWorkspaceContext(makeState([pane]));
+    expect(result).toContain('(claude)');
+  });
+
+  it('returns empty state message when no panes', () => {
+    const result = formatWorkspaceContext(makeState([]));
+    expect(result).toContain('(no sessions)');
+  });
+
+  it('includes row notes when present', () => {
+    const pane = makePane();
+    const state: SerializedWorkspaceState = {
+      panes: [pane],
+      active_pane_id: null,
+      rows: [{ index: 0, note: 'ci row', pane_ids: [1] }],
+    };
+    const result = formatWorkspaceContext(state);
+    expect(result).toContain('note: ci row');
+  });
+});

--- a/src/__tests__/ai-handler.test.ts
+++ b/src/__tests__/ai-handler.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mock all external dependencies ────────────────────────────────────────────
+
+vi.mock('../transport', () => ({
+  transport: { send: vi.fn().mockResolvedValue(null), listen: vi.fn().mockResolvedValue(() => {}) },
+}));
+
+// vi.mock is hoisted to the top of the file before variable declarations, so
+// mockComplete must be declared with vi.hoisted() to be accessible in the factory.
+const { mockComplete } = vi.hoisted(() => ({ mockComplete: vi.fn() }));
+vi.mock('../ai/llm-client', () => ({
+  llmClient: { complete: mockComplete },
+}));
+
+vi.mock('../config/ConfigContext', () => ({
+  configContext: {
+    get: vi.fn().mockReturnValue({
+      workspace_ai: { model: 'claude-test', provider: null, api_key_env: 'ANTHROPIC_API_KEY', base_url: null },
+    }),
+  },
+}));
+
+vi.mock('../session/SessionManager', () => ({
+  sessionManager: {
+    getAllPanes: vi.fn().mockReturnValue([]),
+    getActivePaneId: vi.fn().mockReturnValue(null),
+    getActivePane: vi.fn().mockReturnValue(undefined),
+  },
+}));
+
+vi.mock('../workspace/WorkspaceActions', () => ({
+  workspaceActions: {
+    dispatch: vi.fn().mockResolvedValue({ ok: true, message: 'done', action: {} }),
+    getLog: vi.fn().mockReturnValue([]),
+    configure: vi.fn(),
+    findPane: vi.fn(),
+    actionDescription: vi.fn().mockReturnValue('action desc'),
+  },
+  actionDescription: vi.fn().mockReturnValue('action desc'),
+}));
+
+vi.mock('../workspace/WorkspaceState', () => ({
+  formatWorkspaceContext: vi.fn().mockReturnValue('  1. shell [default] idle auto-name cwd:/home'),
+  serializeWorkspaceState: vi.fn().mockReturnValue({ panes: [], active_pane_id: null, rows: [] }),
+  setWorkspaceLayoutReader: vi.fn(),
+}));
+
+vi.mock('../ai/plan-executor', () => ({
+  planExecutor: {
+    setPending: vi.fn(),
+    getPlanPreview: vi.fn().mockReturnValue('Plan: ...\nConfirm? (y/n)'),
+    isWaitingForConfirm: vi.fn().mockReturnValue(false),
+    handleConfirm: vi.fn().mockResolvedValue('Done.'),
+    enqueue: vi.fn(),
+    clearAll: vi.fn(),
+    pendingCount: vi.fn().mockReturnValue(0),
+  },
+  setPlanLogFn: vi.fn(),
+}));
+
+import { aiHandler } from '../ai/ai-handler';
+
+beforeEach(() => {
+  aiHandler.resetHistory();
+  mockComplete.mockReset();
+  vi.clearAllMocks();
+  // Restore mock implementations cleared by clearAllMocks
+  mockComplete.mockResolvedValue('No action needed.');
+});
+
+// ── Conversation history ──────────────────────────────────────────────────────
+
+describe('AIHandler conversation history', () => {
+  it('includes prior turns in subsequent calls', async () => {
+    mockComplete
+      .mockResolvedValueOnce('First response.')
+      .mockResolvedValueOnce('Second response.');
+
+    await aiHandler.handle('first message');
+    await aiHandler.handle('second message');
+
+    const secondCallMessages = mockComplete.mock.calls[1][0] as Array<{ role: string; content: string }>;
+    const roles = secondCallMessages.map(m => m.role);
+    expect(roles).toContain('user');
+    expect(roles).toContain('assistant');
+
+    // First user message and assistant response should appear in second call
+    const contents = secondCallMessages.map(m => m.content);
+    expect(contents).toContain('first message');
+    expect(contents).toContain('First response.');
+    expect(contents).toContain('second message');
+  });
+
+  it('always places system prompt first', async () => {
+    mockComplete.mockResolvedValue('ok');
+    await aiHandler.handle('hello');
+    await aiHandler.handle('world');
+
+    for (const call of mockComplete.mock.calls) {
+      const messages = call[0] as Array<{ role: string }>;
+      expect(messages[0].role).toBe('system');
+    }
+  });
+
+  it('resetHistory clears conversation', async () => {
+    mockComplete.mockResolvedValue('response');
+    await aiHandler.handle('turn one');
+    aiHandler.resetHistory();
+    await aiHandler.handle('fresh start');
+
+    const messages = mockComplete.mock.calls[1][0] as Array<{ role: string; content: string }>;
+    const contents = messages.map(m => m.content);
+    expect(contents).not.toContain('turn one');
+  });
+
+  it('trims history beyond MAX_HISTORY_TURNS (10 turns = 20 messages)', async () => {
+    mockComplete.mockResolvedValue('ok');
+    // Send 11 turns — history should stay at 10 turns (20 messages) max.
+    for (let i = 0; i < 11; i++) {
+      await aiHandler.handle(`message ${i}`);
+    }
+
+    const lastCall = mockComplete.mock.calls[10][0] as Array<{ role: string; content: string }>;
+    // system prompt (1) + at most 10 turns (20) + current user (1) = 22 max
+    // After trimming oldest pair: system + 10 turns + current = 22
+    const nonSystem = lastCall.filter(m => m.role !== 'system');
+    expect(nonSystem.length).toBeLessThanOrEqual(21); // 10 history turns + 1 current
+  });
+});
+
+// ── System prompt contents ────────────────────────────────────────────────────
+
+describe('system prompt', () => {
+  it('includes new action types: run-await, read, pipeline', async () => {
+    mockComplete.mockResolvedValue('ok');
+    await aiHandler.handle('test');
+
+    const systemMsg = (mockComplete.mock.calls[0][0] as Array<{ role: string; content: string }>)
+      .find(m => m.role === 'system');
+    expect(systemMsg).toBeDefined();
+    expect(systemMsg!.content).toContain('run-await');
+    expect(systemMsg!.content).toContain('read');
+    expect(systemMsg!.content).toContain('pipeline');
+  });
+
+  it('rebuilds workspace context on every call (no stale snapshot)', async () => {
+    const { formatWorkspaceContext } = await import('../workspace/WorkspaceState');
+    mockComplete.mockResolvedValue('ok');
+    await aiHandler.handle('call 1');
+    await aiHandler.handle('call 2');
+    expect(vi.mocked(formatWorkspaceContext).mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/__tests__/waitForCommand.test.ts
+++ b/src/__tests__/waitForCommand.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Capture listener registrations so tests can fire events manually.
+type PayloadHandler = (payload: unknown) => void;
+const registeredListeners = new Map<string, PayloadHandler[]>();
+
+vi.mock('../transport', () => ({
+  transport: {
+    send: vi.fn().mockResolvedValue(null),
+    listen: vi.fn().mockImplementation((event: string, handler: PayloadHandler) => {
+      if (!registeredListeners.has(event)) registeredListeners.set(event, []);
+      registeredListeners.get(event)!.push(handler);
+      return Promise.resolve(() => {
+        const arr = registeredListeners.get(event) ?? [];
+        const idx = arr.indexOf(handler);
+        if (idx >= 0) arr.splice(idx, 1);
+      });
+    }),
+  },
+}));
+
+function emit(event: string, payload: unknown) {
+  for (const handler of registeredListeners.get(event) ?? []) {
+    handler(payload);
+  }
+}
+
+import { waitForCommandComplete } from '../workspace/waitForCommand';
+
+beforeEach(() => {
+  registeredListeners.clear();
+});
+
+describe('waitForCommandComplete', () => {
+  it('resolves with exit code when pane:command_complete fires for matching pane', async () => {
+    const promise = waitForCommandComplete(3);
+    await vi.waitFor(() => registeredListeners.has('pane:command_complete'));
+    emit('pane:command_complete', { pane_id: 3, exit_code: 0 });
+    const result = await promise;
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('resolves with non-zero exit code on failure', async () => {
+    const promise = waitForCommandComplete(5);
+    await vi.waitFor(() => registeredListeners.has('pane:command_complete'));
+    emit('pane:command_complete', { pane_id: 5, exit_code: 127 });
+    const result = await promise;
+    expect(result.exitCode).toBe(127);
+  });
+
+  it('ignores events for a different pane', async () => {
+    const promise = waitForCommandComplete(10, 100);
+    await vi.waitFor(() => registeredListeners.has('pane:command_complete'));
+    // Fire for a different pane — should be ignored.
+    emit('pane:command_complete', { pane_id: 99, exit_code: 0 });
+    // The promise should timeout because pane 10 never completes.
+    await expect(promise).rejects.toThrow('Timeout');
+  });
+
+  it('rejects on timeout', async () => {
+    const promise = waitForCommandComplete(7, 50);
+    await expect(promise).rejects.toThrow('Timeout waiting for pane 7');
+  });
+
+  it('unsubscribes after resolving (no memory leak)', async () => {
+    const promise = waitForCommandComplete(4);
+    await vi.waitFor(() => registeredListeners.has('pane:command_complete'));
+    emit('pane:command_complete', { pane_id: 4, exit_code: 0 });
+    await promise;
+    // A second event for the same pane should not throw.
+    expect(() => emit('pane:command_complete', { pane_id: 4, exit_code: 1 })).not.toThrow();
+  });
+});

--- a/src/ai/ai-handler.ts
+++ b/src/ai/ai-handler.ts
@@ -12,12 +12,20 @@ import { formatWorkspaceContext } from '../workspace/WorkspaceState';
 function buildSystemPrompt(): string {
   const workspaceContext = formatWorkspaceContext();
 
+  const recentLog = workspaceActions.getLog().slice(-5);
+  const recentActions = recentLog.length > 0
+    ? '\nRecent actions:\n' + recentLog
+        .filter(e => e.result != null)
+        .map(e => `  ${e.result!.ok ? '✓' : '✗'} ${actionDescription(e.action)} → ${e.result!.message}`)
+        .join('\n')
+    : '';
+
   return `You are the Workspace AI for FluXTTY, a multi-session developer terminal.
 You help the user accomplish ANY task by running shell commands and managing sessions.
 Use terminal commands freely to get things done — check status, run builds, edit files, whatever is needed.
 
 Current sessions:
-${workspaceContext}
+${workspaceContext}${recentActions}
 
 To execute a workspace action, include a fenced action block in your response:
 
@@ -25,25 +33,30 @@ To execute a workspace action, include a fenced action block in your response:
 {"type": "run", "cmd": "npm test", "target": "frontend"}
 \`\`\`
 
-Available action types (★ = requires confirmation, safe to execute immediately otherwise):
-• run        – run any shell command in one session → {"type":"run","cmd":"...","target":"<name or id>"}
-• broadcast  ★ run in ALL sessions                 → {"type":"broadcast","cmd":"..."}
-• run-group  ★ run in all sessions of a group      → {"type":"run-group","cmd":"...","group":"<group>"}
-• new        – create a new session                → {"type":"new","name":"...","group":"..."}
-• rename     – rename a session                    → {"type":"rename","target":"...","name":"..."}
-• close      – close one session                   → {"type":"close","target":"..."} or "idle"
-• close-group★ close all sessions in a group       → {"type":"close-group","group":"<group>"}
-• split      – split current row                   → {"type":"split"}
-• focus      – navigate to a session               → {"type":"focus","target":"<name or id>"}
-• group      – assign session to a group           → {"type":"group","target":"...","group":"<group>"}
-• note       – set a note on a session             → {"type":"note","target":"...","text":"<note>"}
-• clear      – clear terminal output               → {"type":"clear","target":"<name or id>"}
-• kill       – send Ctrl+C to interrupt a process  → {"type":"kill","target":"<name or id>"}
+Available action types (★ = requires confirmation before execution):
+• run        – run a command (fire-and-forget)      → {"type":"run","cmd":"...","target":"<name or id>"}
+• run-await  – run and wait for exit code           → {"type":"run-await","cmd":"...","target":"<name or id>","timeout_ms":30000}
+• read       – read recent output from a session    → {"type":"read","target":"<name or id>"}
+• pipeline  ★ multi-pane coordinated execution      → {"type":"pipeline","label":"...","steps":[{"label":"...","parallel":true,"condition":"prev-success","actions":[{"target":"...","cmd":"..."}]}]}
+• broadcast ★ run in ALL sessions                   → {"type":"broadcast","cmd":"..."}
+• run-group ★ run in all sessions of a group        → {"type":"run-group","cmd":"...","group":"<group>"}
+• new        – create a new session                 → {"type":"new","name":"...","group":"..."}
+• rename     – rename a session                     → {"type":"rename","target":"...","name":"..."}
+• close      – close one session                    → {"type":"close","target":"..."} or "idle"
+• close-group★ close all sessions in a group        → {"type":"close-group","group":"<group>"}
+• split      – split current row                    → {"type":"split"}
+• focus      – navigate to a session                → {"type":"focus","target":"<name or id>"}
+• group      – assign session to a group            → {"type":"group","target":"...","group":"<group>"}
+• note       – set a note on a session              → {"type":"note","target":"...","text":"<note>"}
+• clear      – clear terminal output                → {"type":"clear","target":"<name or id>"}
+• kill       – send Ctrl+C to interrupt a process   → {"type":"kill","target":"<name or id>"}
 
 Rules:
-- ★ actions (broadcast, run-group, close-group) always require user confirmation — list the plan and wait.
-- All other actions execute immediately for a single session.
-- Chain multiple run actions to accomplish complex tasks step by step.
+- Use run-await (not run) when you need the result before the next action.
+- Use pipeline for multi-step cross-session work with dependencies.
+- pipeline step conditions: "prev-success" = only run if all previous actions exited 0.
+- read lets you inspect output before deciding what to do next.
+- ★ actions always require user confirmation.
 - Keep responses short and direct.`;
 }
 
@@ -141,7 +154,7 @@ function parseIntent(input: string): ParsedIntent | null {
 // ---------------------------------------------------------------------------
 
 /** Read-only actions that never touch state — execute immediately, no confirm. */
-const READONLY_TYPES = new Set(['list', 'help', 'set-agent', 'focus']);
+const READONLY_TYPES = new Set(['list', 'help', 'set-agent', 'focus', 'read']);
 
 const SELF_CONFIRM_TYPES = new Set(['broadcast', 'run-group', 'close-group', 'sequential']);
 
@@ -170,7 +183,16 @@ function describeAction(action: ParsedAction): string {
 // Main AI handler
 // ---------------------------------------------------------------------------
 
+const MAX_HISTORY_TURNS = 10;
+
 class AIHandler {
+  private conversationHistory: LLMMessage[] = [];
+
+  /** Clear the conversation history (e.g. on :clear or new session). */
+  resetHistory(): void {
+    this.conversationHistory = [];
+  }
+
   async handle(input: string): Promise<string> {
     const cfg = configContext.get();
     const model = cfg.workspace_ai.model;
@@ -180,9 +202,18 @@ class AIHandler {
       try {
         const messages: LLMMessage[] = [
           { role: 'system', content: buildSystemPrompt() },
+          ...this.conversationHistory,
           { role: 'user', content: input },
         ];
         const raw = await llmClient.complete(messages, cfg);
+
+        // Update sliding conversation window
+        this.conversationHistory.push({ role: 'user', content: input });
+        this.conversationHistory.push({ role: 'assistant', content: raw });
+        if (this.conversationHistory.length > MAX_HISTORY_TURNS * 2) {
+          this.conversationHistory.splice(0, 2);
+        }
+
         const { actions, cleanText } = extractActions(raw);
 
         if (actions.length === 0) {

--- a/src/ai/ai-handler.ts
+++ b/src/ai/ai-handler.ts
@@ -1,37 +1,23 @@
-import { invoke } from '@tauri-apps/api/core';
 import { sessionManager } from '../session/SessionManager';
-import type { WaterfallArea } from '../waterfall/WaterfallArea';
 import { planExecutor } from './plan-executor';
 import { llmClient, type LLMMessage } from './llm-client';
 import { configContext } from '../config/ConfigContext';
-
-// Will be set after WaterfallArea is created
-let waterfallArea: WaterfallArea | null = null;
-
-export function setWaterfallArea(area: WaterfallArea) {
-  waterfallArea = area;
-}
+import { workspaceActions, actionDescription, type WorkspaceAction } from '../workspace/WorkspaceActions';
+import { formatWorkspaceContext } from '../workspace/WorkspaceState';
 
 // ---------------------------------------------------------------------------
 // Workspace context system prompt
 // ---------------------------------------------------------------------------
 
 function buildSystemPrompt(): string {
-  const panes = sessionManager.getAllPanes();
-  const activeId = sessionManager.getActivePaneId();
-
-  const sessionLines = panes.map(p => {
-    const active = p.id === activeId ? ' ← active' : '';
-    const agent = p.agent_type !== 'none' ? ` (${p.agent_type})` : '';
-    return `  ${p.id}. ${p.name} [${p.group}] ${p.status}${agent}  cwd: ${p.cwd}${active}`;
-  }).join('\n') || '  (no sessions)';
+  const workspaceContext = formatWorkspaceContext();
 
   return `You are the Workspace AI for FluXTTY, a multi-session developer terminal.
 You help the user accomplish ANY task by running shell commands and managing sessions.
 Use terminal commands freely to get things done — check status, run builds, edit files, whatever is needed.
 
 Current sessions:
-${sessionLines}
+${workspaceContext}
 
 To execute a workspace action, include a fenced action block in your response:
 
@@ -157,179 +143,27 @@ function parseIntent(input: string): ParsedIntent | null {
 /** Read-only actions that never touch state — execute immediately, no confirm. */
 const READONLY_TYPES = new Set(['list', 'help', 'set-agent', 'focus']);
 
-/**
- * Actions that manage their own multi-step confirmation via planExecutor.setPlan().
- * Calling executeAction() on these returns the plan preview string and registers
- * the pending plan — no extra wrapping needed.
- */
 const SELF_CONFIRM_TYPES = new Set(['broadcast', 'run-group', 'close-group', 'sequential']);
 
-/** Human-readable description of a single state-changing action (for confirm prompt). */
-function actionDescription(action: ParsedAction): string {
-  switch (action.type) {
-    case 'run':    return `run "${action.cmd as string}" in ${action.target as string}`;
-    case 'new':    return `create new session${action.name ? ` "${action.name as string}"` : ''}${action.group ? ` in group "${action.group as string}"` : ''}`;
-    case 'rename': return `rename "${action.target as string}" → "${action.name as string}"`;
-    case 'close':  return (action.target as string).toLowerCase() === 'idle'
-      ? 'close all idle sessions'
-      : `close session "${action.target as string}"`;
-    case 'split':  return 'split current row';
-    case 'group':  return `move "${action.target as string}" to group "${action.group as string}"`;
-    case 'note':   return `set note on "${action.target as string}": ${action.text as string}`;
-    case 'clear':  return `clear terminal output of "${action.target as string}"`;
-    case 'kill':   return `send Ctrl+C to "${action.target as string}"`;
-    default:       return `${action.type} action`;
+function toWorkspaceAction(action: ParsedAction): WorkspaceAction {
+  if (action.type === 'set-agent' && typeof action.target !== 'string') {
+    const activeId = sessionManager.getActivePaneId();
+    return {
+      type: 'set-agent',
+      target: activeId == null ? '' : String(activeId),
+      agentType: action.agentType as never,
+    };
   }
+  return action as WorkspaceAction;
 }
-
-// ---------------------------------------------------------------------------
-// Pane lookup
-// ---------------------------------------------------------------------------
-
-function findPane(target: string) {
-  const panes = sessionManager.getAllPanes();
-  const t = target.toLowerCase();
-  return panes.find(p =>
-    p.name.toLowerCase() === t ||
-    p.id === parseInt(t)
-  ) || panes.find(p =>
-    p.name.toLowerCase().includes(t)
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Shared action executor (used by both LLM and regex paths)
-// ---------------------------------------------------------------------------
 
 async function executeAction(action: ParsedAction): Promise<string> {
-  switch (action.type) {
-    case 'run': {
-      const pane = findPane(action.target as string);
-      if (!pane) return `Session "${action.target}" not found.`;
-      const tp = waterfallArea?.getPane(pane.id);
-      if (!tp) return `Pane "${action.target}" not available.`;
-      await tp.writeCommand(action.cmd as string);
-      waterfallArea?.scrollToPane(pane.id);
-      return `Ran "${action.cmd}" in ${pane.name}`;
-    }
+  const result = await workspaceActions.dispatch(toWorkspaceAction(action), { source: 'ai' });
+  return result.message;
+}
 
-    case 'broadcast': {
-      const panes = sessionManager.getAllPanes();
-      const plan = panes.map(p => ({ paneId: p.id, cmd: action.cmd as string, paneName: p.name }));
-      planExecutor.setPlan(plan, `Run "${action.cmd}" in all ${panes.length} sessions`);
-      return planExecutor.getPlanPreview();
-    }
-
-    case 'sequential': {
-      const pane = findPane(action.target as string);
-      if (!pane) return `Session "${action.target}" not found.`;
-      const cmds = action.cmds as string[];
-      const plan = cmds.map(cmd => ({ paneId: pane.id, cmd, paneName: pane.name }));
-      planExecutor.setPlan(plan, `Run ${cmds.length} commands in ${pane.name}`);
-      return planExecutor.getPlanPreview();
-    }
-
-    case 'new': {
-      if (!waterfallArea) return 'Waterfall not ready.';
-      const pane = await waterfallArea.spawnPane({ newRow: true, group: (action.group as string) || 'default' });
-      if (pane && action.name) {
-        await sessionManager.renamePane(pane.paneId, action.name as string);
-      }
-      return pane
-        ? `Created new session${action.name ? ` "${action.name}"` : ''}`
-        : 'Failed to create session.';
-    }
-
-    case 'rename': {
-      const pane = findPane(action.target as string);
-      if (!pane) return `Session "${action.target}" not found.`;
-      await sessionManager.renamePane(pane.id, action.name as string);
-      return `Renamed ${pane.name} → ${action.name}`;
-    }
-
-    case 'close': {
-      const target = (action.target as string).toLowerCase();
-      if (target === 'idle') {
-        const idle = sessionManager.getAllPanes().filter(p => p.status === 'idle');
-        for (const p of idle) {
-          const tp = waterfallArea?.getPane(p.id);
-          if (tp) await tp.destroy();
-        }
-        return `Closed ${idle.length} idle session(s).`;
-      }
-      const pane = findPane(action.target as string);
-      if (!pane) return `Session "${action.target}" not found.`;
-      const tp = waterfallArea?.getPane(pane.id);
-      if (tp) {
-        await tp.destroy();
-        return `Closed ${pane.name}.`;
-      }
-      return 'Pane not available.';
-    }
-
-    case 'split': {
-      if (!waterfallArea) return 'Waterfall not ready.';
-      waterfallArea.splitCurrentRow();
-      return 'Split current row.';
-    }
-
-    case 'focus': {
-      const pane = findPane(action.target as string);
-      if (!pane) return `Session "${action.target}" not found.`;
-      sessionManager.setActivePane(pane.id);
-      waterfallArea?.scrollToPane(pane.id);
-      return `Focused ${pane.name}.`;
-    }
-
-    case 'group': {
-      const pane = findPane(action.target as string);
-      if (!pane) return `Session "${action.target}" not found.`;
-      await sessionManager.setPaneGroup(pane.id, action.group as string);
-      return `Moved ${pane.name} to group "${action.group}".`;
-    }
-
-    case 'note': {
-      const pane = findPane(action.target as string);
-      if (!pane) return `Session "${action.target}" not found.`;
-      await sessionManager.setPaneNote(pane.id, action.text as string);
-      return `Set note on ${pane.name}.`;
-    }
-
-    case 'clear': {
-      const pane = findPane(action.target as string);
-      if (!pane) return `Session "${action.target}" not found.`;
-      await invoke('pty_write', { args: { pane_id: pane.id, data: 'clear\r' } });
-      return `Cleared ${pane.name}.`;
-    }
-
-    case 'kill': {
-      const pane = findPane(action.target as string);
-      if (!pane) return `Session "${action.target}" not found.`;
-      await invoke('pty_write', { args: { pane_id: pane.id, data: '\x03' } });
-      return `Sent Ctrl+C to ${pane.name}.`;
-    }
-
-    case 'run-group': {
-      const group = (action.group as string).toLowerCase();
-      const groupPanes = sessionManager.getAllPanes().filter(p => p.group.toLowerCase() === group);
-      if (groupPanes.length === 0) return `No sessions in group "${action.group}".`;
-      const plan = groupPanes.map(p => ({ paneId: p.id, cmd: action.cmd as string, paneName: p.name }));
-      planExecutor.setPlan(plan, `Run "${action.cmd}" in group "${action.group}" (${groupPanes.length} sessions)`);
-      return planExecutor.getPlanPreview();
-    }
-
-    case 'close-group': {
-      const group = (action.group as string).toLowerCase();
-      const groupPanes = sessionManager.getAllPanes().filter(p => p.group.toLowerCase() === group);
-      if (groupPanes.length === 0) return `No sessions in group "${action.group}".`;
-      const plan = groupPanes.map(p => ({ paneId: p.id, cmd: '__close__', paneName: p.name }));
-      planExecutor.setPlan(plan, `Close all ${groupPanes.length} sessions in group "${action.group}"`);
-      return planExecutor.getPlanPreview();
-    }
-
-    default:
-      return `Unknown action type: ${action.type}`;
-  }
+function describeAction(action: ParsedAction): string {
+  return actionDescription(toWorkspaceAction(action));
 }
 
 // ---------------------------------------------------------------------------
@@ -378,48 +212,23 @@ class AIHandler {
         if (changingActions.length === 1) {
           // Single state-changing action — show confirm prompt
           const a = changingActions[0];
-          const desc = actionDescription(a);
-          planExecutor.setPending(desc, () => executeAction(a));
+          const desc = describeAction(a);
+          planExecutor.setPending(desc, () => executeAction(a), [toWorkspaceAction(a)]);
           const preview = (cleanText ? cleanText + '\n\n' : '') + planExecutor.getPlanPreview();
           return preview;
         }
 
-        // Multiple state-changing actions — build a unified plan for run/close,
-        // execute self-confirm types inline, execute readonly immediately.
-        const planSteps = changingActions
-          .filter(a => !SELF_CONFIRM_TYPES.has(a.type))
-          .flatMap(a => {
-            if (a.type === 'run') {
-              const pane = findPane(a.target as string);
-              return pane ? [{ paneId: pane.id, cmd: a.cmd as string, paneName: pane.name }] : [];
-            }
-            if (a.type === 'close') {
-              const pane = findPane(a.target as string);
-              return pane ? [{ paneId: pane.id, cmd: '__close__', paneName: pane.name }] : [];
-            }
-            // Other actions (new/rename/etc.) are described inline in the plan title
-            return [];
-          });
-        const nonPlanActions = changingActions.filter(
-          a => !SELF_CONFIRM_TYPES.has(a.type) && a.type !== 'run' && a.type !== 'close'
-        );
-        const descriptions = [
-          ...nonPlanActions.map(a => actionDescription(a)),
-          ...planSteps.map(s => `${s.paneName} ❯ ${s.cmd === '__close__' ? '[close]' : s.cmd}`),
-        ];
+        // Multiple state-changing actions share the same confirmation queue.
+        const descriptions = changingActions.map(a => describeAction(a));
+        const queuedActions = changingActions.map(a => toWorkspaceAction(a));
         planExecutor.setPending(
           descriptions.join('\n'),
           async () => {
-            for (const a of nonPlanActions) await executeAction(a);
-            for (const s of planSteps) {
-              const tp = waterfallArea?.getPane(s.paneId);
-              if (tp) {
-                if (s.cmd === '__close__') await tp.destroy();
-                else await tp.writeCommand(s.cmd);
-              }
-            }
-            return 'Done.';
-          }
+            const messages: string[] = [];
+            for (const a of changingActions) messages.push(await executeAction(a));
+            return messages.join('\n');
+          },
+          queuedActions,
         );
         return (cleanText ? cleanText + '\n\n' : '') + planExecutor.getPlanPreview();
 
@@ -447,8 +256,11 @@ class AIHandler {
       case 'set-agent': {
         const activeId = sessionManager.getActivePaneId();
         if (activeId == null) return 'No active session.';
-        await sessionManager.setPaneAgent(activeId, intent.agentType as never);
-        return `Set active session agent to "${intent.agentType}".`;
+        return executeAction({
+          type: 'set-agent',
+          target: String(activeId),
+          agentType: intent.agentType,
+        });
       }
 
       case 'focus':
@@ -474,7 +286,7 @@ class AIHandler {
           '  list | status                   – list all sessions',
           '  !agent <claude|codex|aider|none>',
           '',
-          'Set workspace_ai.model in config to enable natural language (Claude, GPT, Gemini, Ollama…)',
+          'Set workspace_ai.model to an OpenCode-style provider/model id, for example anthropic/claude-sonnet-4-5.',
         ].join('\n');
 
       // ── State-changing: self-managing confirmation ─────────────────
@@ -487,8 +299,8 @@ class AIHandler {
       // ── State-changing: single action — route through confirm ──────
       default: {
         const action = intent as ParsedAction;
-        const desc = actionDescription(action);
-        planExecutor.setPending(desc, () => executeAction(action));
+        const desc = describeAction(action);
+        planExecutor.setPending(desc, () => executeAction(action), [toWorkspaceAction(action)]);
         return planExecutor.getPlanPreview();
       }
     }

--- a/src/ai/llm-client.ts
+++ b/src/ai/llm-client.ts
@@ -1,9 +1,92 @@
-import { invoke } from '@tauri-apps/api/core';
-import type { AppConfig } from '../config/ConfigContext';
+import { transport } from '../transport';
+import type { AiProviderConfig, AppConfig } from '../config/ConfigContext';
 
 export interface LLMMessage {
   role: 'system' | 'user' | 'assistant';
   content: string;
+}
+
+interface ResolvedModelConfig {
+  providerId: string;
+  modelId: string;
+  apiKey?: string;
+  apiKeyEnv?: string;
+  baseURL?: string;
+  options: Record<string, unknown>;
+}
+
+function inferProvider(model: string): string {
+  if (model === 'claude-cli') return 'claude-cli';
+  if (model.startsWith('claude-')) return 'anthropic';
+  if (model.startsWith('gpt-') || model.startsWith('o1-') || model.startsWith('o3-')
+      || model.startsWith('o4-') || model.startsWith('chatgpt-')) return 'openai';
+  if (model.startsWith('gemini-')) return 'google';
+  if (model.startsWith('ollama/') || model.startsWith('ollama:')) return 'ollama';
+  return 'openai';
+}
+
+function providerMap(provider: AppConfig['workspace_ai']['provider']): Record<string, AiProviderConfig> {
+  if (!provider || typeof provider === 'string') return {};
+  return provider;
+}
+
+function firstProviderId(providers: Record<string, AiProviderConfig>): string | null {
+  const keys = Object.keys(providers);
+  return keys.length === 1 ? keys[0] : null;
+}
+
+function splitModel(model: string, providers: Record<string, AiProviderConfig>): { providerId: string; modelKey: string } {
+  const slash = model.indexOf('/');
+  if (slash > 0) {
+    return {
+      providerId: model.slice(0, slash),
+      modelKey: model.slice(slash + 1),
+    };
+  }
+
+  return {
+    providerId: firstProviderId(providers) ?? inferProvider(model),
+    modelKey: model,
+  };
+}
+
+function stringOption(options: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = options[key];
+    if (typeof value === 'string' && value.trim()) return value;
+  }
+  return undefined;
+}
+
+function resolveModelConfig(cfg: AppConfig): ResolvedModelConfig | null {
+  const wai = cfg.workspace_ai;
+  const model = wai.model?.trim();
+  if (!model || model === 'none') return null;
+
+  const providers = providerMap(wai.provider);
+  const { providerId, modelKey } = splitModel(model, providers);
+  if (providerId === 'claude-cli' || model === 'claude-cli') {
+    return {
+      providerId: 'claude-cli',
+      modelId: 'claude-cli',
+      options: {},
+    };
+  }
+
+  const providerCfg = providers[providerId] ?? {};
+  const providerOptions = providerCfg.options ?? {};
+  const modelCfg = providerCfg.models?.[modelKey];
+  const modelOptions = modelCfg?.options ?? {};
+  const options = { ...providerOptions, ...modelOptions };
+
+  return {
+    providerId,
+    modelId: modelCfg?.id || modelKey,
+    apiKey: stringOption(options, ['apiKey', 'api_key']),
+    apiKeyEnv: wai.api_key_env,
+    baseURL: stringOption(options, ['baseURL', 'base_url']) ?? wai.base_url ?? undefined,
+    options,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -15,8 +98,10 @@ export class LLMClient {
   async complete(messages: LLMMessage[], cfg: AppConfig): Promise<string> {
     const wai = cfg.workspace_ai;
     if (!wai.model || wai.model === 'none') return '';
+    const resolved = resolveModelConfig(cfg);
+    if (!resolved) return '';
 
-    if (wai.model === 'claude-cli') {
+    if (resolved.providerId === 'claude-cli') {
       // claude-cli uses a subprocess, handled by its own IPC command
       const systemParts = messages.filter(m => m.role === 'system').map(m => m.content);
       const lastUser = [...messages].reverse().find(m => m.role === 'user');
@@ -24,17 +109,19 @@ export class LLMClient {
       const prompt = systemParts.length > 0
         ? systemParts.join('\n\n') + '\n\n' + lastUser.content
         : lastUser.content;
-      return invoke<string>('claude_cli_query', { prompt });
+      return transport.send<string>('claude_cli_query', { prompt });
     }
 
     // All other providers: delegate to Rust for native HTTP (no CORS, no fetch restrictions)
-    return invoke<string>('llm_complete', {
+    return transport.send<string>('llm_complete', {
       args: {
         messages: messages.map(m => ({ role: m.role, content: m.content })),
-        model: wai.model,
-        provider: wai.provider ?? null,
-        api_key_env: wai.api_key_env ?? null,
-        base_url: wai.base_url ?? null,
+        model: resolved.modelId,
+        provider: resolved.providerId,
+        api_key: resolved.apiKey ?? null,
+        api_key_env: resolved.apiKeyEnv ?? null,
+        base_url: resolved.baseURL ?? null,
+        options: resolved.options,
       },
     });
   }

--- a/src/ai/plan-executor.ts
+++ b/src/ai/plan-executor.ts
@@ -1,109 +1,94 @@
-import type { WaterfallArea } from '../waterfall/WaterfallArea';
+import type { WorkspaceAction, WorkspaceActionResult } from '../workspace/WorkspaceActions';
 
-interface PlanStep {
-  paneId: number;
-  cmd: string;
-  paneName: string;
+export interface PendingActionBatch {
+  id: string;
+  title: string;
+  preview: string;
+  actions: WorkspaceAction[];
+  execute(): Promise<WorkspaceActionResult[]>;
 }
 
 type PlanLogFn = (text: string, cls?: string) => void;
 
-let waterfallArea: WaterfallArea | null = null;
 let logFn: PlanLogFn | null = null;
-
-export function setPlanWaterfallArea(area: WaterfallArea) {
-  waterfallArea = area;
-}
 
 export function setPlanLogFn(fn: PlanLogFn) {
   logFn = fn;
 }
 
 class PlanExecutor {
-  private plan: PlanStep[] | null = null;
-  private planTitle = '';
-  // Generic single-action confirmation: stores preview text + executor callback
-  private pendingPreview: string | null = null;
-  private pendingFn: (() => Promise<string>) | null = null;
+  private queue: PendingActionBatch[] = [];
+  private nextId = 1;
 
-  setPlan(steps: PlanStep[], title: string) {
-    this.plan = steps;
-    this.planTitle = title;
-    this.pendingPreview = null;
-    this.pendingFn = null;
+  enqueue(batch: PendingActionBatch) {
+    this.queue.push(batch);
   }
 
   /** Confirm a single arbitrary action without a multi-step plan. */
-  setPending(preview: string, fn: () => Promise<string>) {
-    this.plan = null;
-    this.planTitle = '';
-    this.pendingPreview = preview;
-    this.pendingFn = fn;
+  setPending(preview: string, fn: () => Promise<string>, actions: WorkspaceAction[] = []) {
+    const id = `pending-${this.nextId++}`;
+    this.enqueue({
+      id,
+      title: 'Pending action',
+      preview,
+      actions,
+      execute: async () => [{
+        ok: true,
+        message: await fn(),
+        action: actions[0] ?? { type: 'focus', target: '' },
+      }],
+    });
   }
 
   getPlanPreview(): string {
-    if (this.plan) {
-      const lines = [`Plan: ${this.planTitle}`, ''];
-      for (const step of this.plan) {
-        const display = step.cmd === '__close__' ? '[close session]' : `❯ ${step.cmd}`;
-        lines.push(`  ${step.paneName} ${display}`);
-      }
-      lines.push('', 'Confirm? (y/n)');
-      return lines.join('\n');
+    const current = this.queue[0];
+    if (!current) return '';
+
+    const lines: string[] = [];
+    if (current.title !== 'Pending action') {
+      lines.push(`${this.queue.length > 1 ? `Plan 1/${this.queue.length}:` : 'Plan:'} ${current.title}`, '');
+    } else if (this.queue.length > 1) {
+      lines.push(`Plan 1/${this.queue.length}: ${current.title}`, '');
     }
-    if (this.pendingPreview) {
-      return this.pendingPreview + '\n\nConfirm? (y/n)';
-    }
-    return '';
+    lines.push(current.preview.trim(), '', 'Confirm? (y/n)');
+    return lines.join('\n');
   }
 
   isWaitingForConfirm(): boolean {
-    return this.plan !== null || this.pendingFn !== null;
+    return this.queue.length > 0;
+  }
+
+  pendingCount(): number {
+    return this.queue.length;
+  }
+
+  clearAll() {
+    this.queue = [];
   }
 
   async handleConfirm(input: string): Promise<string> {
-    if (!this.isWaitingForConfirm()) return '';
+    const current = this.queue[0];
+    if (!current) return '';
 
     if (input.trim().toLowerCase() === 'y') {
-      if (this.plan) {
-        const plan = this.plan;
-        this.plan = null;
-        await this.executePlan(plan);
-        return 'Done.';
+      this.queue.shift();
+      const results = await current.execute();
+      for (const result of results) {
+        if (logFn) logFn(`  ${result.message}`, result.ok ? 'plan-step' : 'error');
       }
-      if (this.pendingFn) {
-        const fn = this.pendingFn;
-        this.pendingFn = null;
-        this.pendingPreview = null;
-        return fn();
-      }
+      const summary = results.length > 0
+        ? results.map(result => result.message).join('\n')
+        : 'Done.';
+      return this.queue.length > 0
+        ? `${summary}\n\n${this.getPlanPreview()}`
+        : summary;
     }
 
-    this.plan = null;
-    this.pendingFn = null;
-    this.pendingPreview = null;
-    return 'Cancelled.';
+    this.queue.shift();
+    return this.queue.length > 0
+      ? `Cancelled.\n\n${this.getPlanPreview()}`
+      : 'Cancelled.';
   }
-
-  private async executePlan(steps: PlanStep[]) {
-    for (const step of steps) {
-      const display = step.cmd === '__close__' ? '[close]' : `❯ ${step.cmd}`;
-      if (logFn) logFn(`  ${step.paneName} ${display}`, 'plan-step');
-      const tp = waterfallArea?.getPane(step.paneId);
-      if (tp) {
-        if (step.cmd === '__close__') {
-          await tp.destroy();
-        } else {
-          await tp.writeCommand(step.cmd);
-        }
-      }
-      await delay(300);
-    }
-  }
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 export const planExecutor = new PlanExecutor();

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,22 +1,26 @@
 import { getCurrentWindow } from '@tauri-apps/api/window';
-import { invoke } from '@tauri-apps/api/core';
 import { sessionManager } from './session/SessionManager';
+import { sessionObserver } from './session/SessionObserver';
 import { configContext } from './config/ConfigContext';
 import { WaterfallArea } from './waterfall/WaterfallArea';
 import { InputBar } from './input/InputBar';
 import { SessionSidebar } from './sidebar/SessionSidebar';
 import { keybindingManager } from './keybindings/KeybindingManager';
 import { modeManager } from './input/ModeManager';
-import { setWaterfallArea } from './ai/ai-handler';
-import { setPlanWaterfallArea, setPlanLogFn } from './ai/plan-executor';
+import { setPlanLogFn } from './ai/plan-executor';
 import { SettingsPanel } from './settings/SettingsPanel';
 import { OnboardingOverlay } from './help/OnboardingOverlay';
+import { transport } from './transport';
+import { workspaceActions } from './workspace/WorkspaceActions';
+import { setWorkspaceLayoutReader } from './workspace/WorkspaceState';
+import type { PaneNameSource } from './session/types';
 
 interface PaneSnapshot {
   name: string;
   group: string;
   note: string;
   cwd: string;
+  name_source?: PaneNameSource;
   row_index: number;
   pane_index: number;
   is_active: boolean;
@@ -38,6 +42,7 @@ export async function initApp(root: HTMLElement) {
   // Init config first
   await configContext.init();
   await sessionManager.init();
+  sessionObserver.init();
 
   // Preload bundled symbol font before any xterm.js terminal is created.
   // xterm.js builds its glyph atlas on first render — if the @font-face font
@@ -77,17 +82,35 @@ export async function initApp(root: HTMLElement) {
   const inputBar = new InputBar(appEl);
 
   // Wire up cross-module references
-  sidebar.setWaterfallArea(waterfallArea);
-  setWaterfallArea(waterfallArea);
-  setPlanWaterfallArea(waterfallArea);
   setPlanLogFn((text, cls) => inputBar.logLine(text, cls));
+  setWorkspaceLayoutReader(waterfallArea);
+  workspaceActions.configure({
+    session: sessionManager,
+    terminal: {
+      write: (paneId, data) => transport.send('pty_write', { args: { pane_id: paneId, data } }),
+    },
+    layout: {
+      spawnPane: async (opts) => {
+        const pane = await waterfallArea.spawnPane(opts);
+        return pane ? { paneId: pane.paneId } : null;
+      },
+      splitCurrentRow: () => waterfallArea.splitCurrentRow(),
+      closePane: async (paneId) => {
+        const pane = waterfallArea.getPane(paneId);
+        if (pane) await pane.destroy();
+      },
+    },
+    viewport: {
+      scrollToPane: (paneId) => waterfallArea.scrollToPane(paneId),
+    },
+  });
 
   // Header buttons
   header.querySelector('#btn-new')?.addEventListener('click', () => {
-    waterfallArea.spawnPane({ newRow: true });
+    void workspaceActions.dispatch({ type: 'new' }, { source: 'ui' });
   });
   header.querySelector('#btn-split')?.addEventListener('click', () => {
-    waterfallArea.splitCurrentRow();
+    void workspaceActions.dispatch({ type: 'split' }, { source: 'ui' });
   });
   header.querySelector('#btn-sessions')?.addEventListener('click', () => {
     sidebar.toggle();
@@ -116,7 +139,7 @@ export async function initApp(root: HTMLElement) {
   // CSS cannot cover native controls; this uses objc FFI to setHidden on each button.
   if (isMac) {
     const applyTrafficLights = (compact: boolean) => {
-      invoke('window_set_traffic_lights_hidden', { hidden: compact }).catch(() => {});
+      transport.send('window_set_traffic_lights_hidden', { hidden: compact }).catch(() => {});
     };
     applyTrafficLights(configContext.get().window.compact_mode);
     configContext.onChange((cfg) => applyTrafficLights(cfg.window.compact_mode));
@@ -144,11 +167,11 @@ export async function initApp(root: HTMLElement) {
   // appWindow.destroy() is used for the final close so it doesn't re-fire
   // onCloseRequested (unlike appWindow.close()).
   appWindow.onCloseRequested(async (event) => {
-    if (!configContext.get().persistence.keep_alive) return;
+    if (!configContext.get().persistence.restore_workspace_on_launch) return;
     event.preventDefault();
     try {
       const snapshot = buildSnapshot(waterfallArea);
-      await invoke('workspace_snapshot_save', { snapshot });
+      await transport.send('workspace_snapshot_save', { snapshot });
     } catch (e) {
       console.error('Failed to save workspace snapshot:', e);
     }
@@ -174,9 +197,9 @@ export async function initApp(root: HTMLElement) {
 
   // ── Persistence: restore snapshot or spawn a fresh pane ─────────────────
   let restored = false;
-  if (configContext.get().persistence.keep_alive) {
+  if (configContext.get().persistence.restore_workspace_on_launch) {
     try {
-      const snapshot = await invoke<WorkspaceSnapshot | null>('workspace_snapshot_load');
+      const snapshot = await transport.send<WorkspaceSnapshot | null>('workspace_snapshot_load');
       console.log('[restore] snapshot loaded:', snapshot);
       if (snapshot && snapshot.panes.length > 0) {
         await restoreSnapshot(snapshot, waterfallArea);
@@ -187,7 +210,7 @@ export async function initApp(root: HTMLElement) {
       console.error('[restore] failed:', e);
     }
   } else {
-    console.log('[restore] skipped: keep_alive=false');
+    console.log('[restore] skipped: restore_workspace_on_launch=false');
   }
   if (!restored) {
     await waterfallArea.spawnPane({ newRow: true });
@@ -229,6 +252,7 @@ function buildSnapshot(waterfallArea: WaterfallArea): WorkspaceSnapshot {
         // Store row note only on first pane in row; other panes leave it empty.
         note: paneIdx === 0 ? rowNote : '',
         cwd: info.cwd,
+        name_source: info.name_source,
         row_index: rowIdx,
         pane_index: paneIdx,
         is_active: info.id === activeId,
@@ -270,7 +294,7 @@ async function restoreSnapshot(snapshot: WorkspaceSnapshot, waterfallArea: Water
 
     // Restore metadata that the PTY spawn doesn't carry.
     const renames: Promise<void>[] = [];
-    if (snap.name) renames.push(sessionManager.renamePane(pane.paneId, snap.name).catch(console.error));
+    if (snap.name) renames.push(sessionManager.renamePane(pane.paneId, snap.name, snap.name_source ?? 'manual').catch(console.error));
     if (snap.group && snap.group !== 'default') {
       renames.push(sessionManager.setPaneGroup(pane.paneId, snap.group).catch(console.error));
     }

--- a/src/config/ConfigContext.ts
+++ b/src/config/ConfigContext.ts
@@ -1,5 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
-import { listen } from '@tauri-apps/api/event';
+import { transport } from '../transport';
 
 interface RgbColor {
   r: number;
@@ -51,19 +50,41 @@ export interface AppConfig {
   keybindings: Array<{ key: string; mods: string | null; action: string }>;
   input: { live_typing: boolean; workspace_scroll_modifier: string };
   workspace_ai: {
-    /** anthropic | openai | google | ollama | claude-cli | none  (inferred from model if omitted) */
-    provider: string | null;
-    /** Model name: claude-sonnet-4-6 | gpt-4o | gemini-2.0-flash | ollama/llama3 | none | claude-cli */
+    /** OpenCode-style provider/model id: anthropic/claude-sonnet-4-5, openai/gpt-4o, ollama/llama3 */
     model: string;
-    /** Env var name holding the API key */
-    api_key_env: string;
-    /** Base URL override — required for Ollama, useful for OpenAI-compatible endpoints */
-    base_url: string | null;
+    small_model?: string | null;
+    /** OpenCode-style provider map keyed by provider id. */
+    provider: Record<string, AiProviderConfig> | string | null;
+    /** Legacy fields retained for old configs. Prefer provider.<id>.options.apiKey/baseURL. */
+    api_key_env?: string;
+    base_url?: string | null;
     always_confirm_broadcast: boolean;
     always_confirm_multi_step: boolean;
+    agent_relay_auto_submit?: boolean;
   };
   waterfall: { row_height_mode: string; fixed_row_height: number; scroll_snap: boolean; new_pane_focus: boolean; note_width: number; pane_min_width: number; show_note_button: boolean; inactive_pane_scrim_strength: number };
-  persistence: { keep_alive: boolean; scrollback_lines: number; save_scrollback_on_exit: boolean };
+  persistence: { restore_workspace_on_launch: boolean; scrollback_lines: number; save_scrollback_on_exit: boolean };
+}
+
+export interface AiProviderConfig {
+  name?: string | null;
+  npm?: string | null;
+  options?: Record<string, unknown>;
+  models?: Record<string, AiModelConfig>;
+}
+
+export interface AiModelConfig {
+  id?: string | null;
+  name?: string | null;
+  options?: Record<string, unknown>;
+  variants?: Record<string, AiModelVariantConfig>;
+}
+
+export interface AiModelVariantConfig {
+  id?: string | null;
+  name?: string | null;
+  disabled?: boolean;
+  options?: Record<string, unknown>;
 }
 
 type ConfigListener = (config: AppConfig) => void;
@@ -73,11 +94,11 @@ class ConfigContext {
   private listeners: ConfigListener[] = [];
 
   async init() {
-    this.config = await invoke<AppConfig>('config_get');
+    this.config = await transport.send<AppConfig>('config_get');
     this.applyToDOM(this.config);
 
-    await listen<AppConfig>('config:changed', (event) => {
-      this.config = event.payload;
+    await transport.listen<AppConfig>('config:changed', (config) => {
+      this.config = config;
       this.applyToDOM(this.config);
       this.listeners.forEach(l => l(this.config!));
     });

--- a/src/input/InputBar.ts
+++ b/src/input/InputBar.ts
@@ -253,15 +253,22 @@ export class InputBar {
     const active = document.activeElement;
     const target = e.target instanceof Element ? e.target : null;
     const focusInTextEditor = isEditableElement(active) || isEditableElement(target);
-    if (mode.type === 'normal' && active !== this.inputEl && !focusInTextEditor && !this.paneSelector.isOpen()) {
-      // Meta-modified keys are global app shortcuts (Quit, Settings, ClosePane…)
-      // handled by KeybindingManager. Don't intercept them here — KeybindingManager
-      // runs its own document capture listener AFTER this window listener, and it
-      // checks e.defaultPrevented. If we call handleKeyDown first it calls
-      // e.preventDefault() and KeybindingManager silently skips the shortcut.
-      if (e.metaKey) return;
-      this.inputEl.focus();
-      this.handleKeyDown(e);
+    if (active !== this.inputEl && !focusInTextEditor && !this.paneSelector.isOpen()) {
+      if (mode.type === 'normal') {
+        // Meta-modified keys are global app shortcuts (Quit, Settings, ClosePane…)
+        // handled by KeybindingManager. Don't intercept them here — KeybindingManager
+        // runs its own document capture listener AFTER this window listener, and it
+        // checks e.defaultPrevented. If we call handleKeyDown first it calls
+        // e.preventDefault() and KeybindingManager silently skips the shortcut.
+        if (e.metaKey) return;
+        this.inputEl.focus();
+        this.handleKeyDown(e);
+      } else if (mode.type === 'insert') {
+        // Focus was stolen (e.g. clicking a close button). Re-anchor to inputEl
+        // and forward the keystroke so nothing is lost.
+        this.inputEl.focus();
+        this.handleKeyDown(e);
+      }
     }
   }
 
@@ -648,7 +655,7 @@ export class InputBar {
 
   private async submitToShell() {
     const text = this.inputEl.value;
-    if (!text.trim() && text === '') {
+    if (!text.trim()) {
       // Empty Enter still sends newline (e.g. confirms prompts in shell/claude)
       const activeId = sessionManager.getActivePaneId();
       if (activeId == null) return;

--- a/src/input/InputBar.ts
+++ b/src/input/InputBar.ts
@@ -1,4 +1,3 @@
-import { invoke } from '@tauri-apps/api/core';
 import type { InputMode, AgentType } from '../session/types';
 import { AGENT_SLASH_COMMANDS } from '../session/types';
 import { modeManager } from './ModeManager';
@@ -7,9 +6,10 @@ import { PaneSelector } from './PaneSelector';
 import { sessionManager } from '../session/SessionManager';
 import { aiHandler } from '../ai/ai-handler';
 import { planExecutor } from '../ai/plan-executor';
-import { suggestName, isSignificantCommand, isDefaultName, markAutoNamed, isAutoNamed } from '../session/AutoNamer';
 import { configContext } from '../config/ConfigContext';
 import { hintManager, type ActiveHint } from '../hints/HintManager';
+import { transport } from '../transport';
+import { workspaceActions } from '../workspace/WorkspaceActions';
 
 function longestCommonPrefix(strs: string[]): string {
   if (strs.length === 0) return '';
@@ -652,7 +652,7 @@ export class InputBar {
       // Empty Enter still sends newline (e.g. confirms prompts in shell/claude)
       const activeId = sessionManager.getActivePaneId();
       if (activeId == null) return;
-      await invoke('pty_write', { args: { pane_id: activeId, data: '\r' } }).catch(console.error);
+      await workspaceActions.dispatch({ type: 'write', target: String(activeId), data: '\r' }, { source: 'ui' }).catch(console.error);
       return;
     }
 
@@ -669,20 +669,7 @@ export class InputBar {
     const activeId = sessionManager.getActivePaneId();
     if (activeId == null) return;
 
-    // Auto-name pane only for significant commands (AI agents, editors, interactive sessions).
-    // Transient commands (ls, git, cd, npm run…) leave the cwd-derived name unchanged.
-    if (isSignificantCommand(text.trim())) {
-      const pane = sessionManager.getActivePane();
-      if (pane && (isDefaultName(pane.name) || isAutoNamed(pane.id))) {
-        const suggested = suggestName(text.trim(), pane.cwd);
-        if (suggested) {
-          sessionManager.renamePane(activeId, suggested);
-          markAutoNamed(activeId);
-        }
-      }
-    }
-
-    await invoke('pty_write', { args: { pane_id: activeId, data: text + '\r' } }).catch(console.error);
+    await workspaceActions.dispatch({ type: 'run', target: String(activeId), cmd: text }, { source: 'ui' }).catch(console.error);
     document.dispatchEvent(new CustomEvent('scroll-to-active-pane'));
     this.notifyInsertCommandSubmitted(text, activeId);
   }
@@ -690,7 +677,7 @@ export class InputBar {
   private async sendKeyToPTY(data: string) {
     const activeId = sessionManager.getActivePaneId();
     if (activeId == null) return;
-    await invoke('pty_write', { args: { pane_id: activeId, data } }).catch(console.error);
+    await workspaceActions.dispatch({ type: 'write', target: String(activeId), data }, { source: 'ui' }).catch(console.error);
   }
 
   // ── Local command history ─────────────────────────────────────────
@@ -749,8 +736,7 @@ export class InputBar {
 
   private handlePaneSelected(paneId: number) {
     this.inputEl.value = '';
-    sessionManager.setActivePane(paneId);
-    document.dispatchEvent(new CustomEvent('scroll-to-active-pane'));
+    void workspaceActions.dispatch({ type: 'focus', target: String(paneId) }, { source: 'ui' });
     this.inputEl.focus();
     modeManager.enterNormal();
   }
@@ -977,7 +963,7 @@ export class InputBar {
 
     let completions: string[];
     try {
-      completions = await invoke<string[]>('shell_complete', { args: { input, cwd } });
+      completions = await transport.send<string[]>('shell_complete', { args: { input, cwd } });
     } catch (e) {
       console.error('shell_complete error:', e);
       return;

--- a/src/keybindings/KeybindingManager.ts
+++ b/src/keybindings/KeybindingManager.ts
@@ -1,10 +1,10 @@
 import { getCurrentWindow } from '@tauri-apps/api/window';
-import { invoke } from '@tauri-apps/api/core';
 import { configContext } from '../config/ConfigContext';
 import type { WaterfallArea } from '../waterfall/WaterfallArea';
 import { modeManager } from '../input/ModeManager';
 import { sessionManager } from '../session/SessionManager';
 import type { SessionSidebar } from '../sidebar/SessionSidebar';
+import { workspaceActions } from '../workspace/WorkspaceActions';
 
 interface ActionHandlers {
   waterfallArea: WaterfallArea;
@@ -101,10 +101,10 @@ export class KeybindingManager {
 
     switch (action) {
       case 'NewTerminal':
-        waterfallArea.spawnPane({ newRow: true });
+        void workspaceActions.dispatch({ type: 'new' }, { source: 'keyboard' });
         break;
       case 'SplitHorizontal':
-        waterfallArea.splitCurrentRow();
+        void workspaceActions.dispatch({ type: 'split' }, { source: 'keyboard' });
         break;
       case 'ClosePane': {
         const pane = waterfallArea.getActivePane();
@@ -114,7 +114,7 @@ export class KeybindingManager {
           const ok = confirm(`Close "${info.name}"? A process is still running.`);
           if (!ok) break;
         }
-        pane.destroy();
+        void workspaceActions.dispatch({ type: 'close', target: String(pane.paneId) }, { source: 'keyboard' });
         modeManager.enterNormal();
         break;
       }
@@ -155,8 +155,7 @@ export class KeybindingManager {
               if (dist < minDist) { minDist = dist; targetId = p.id; }
             }
           }
-          sessionManager.setActivePane(targetId);
-          waterfallArea.scrollToPane(targetId);
+          void workspaceActions.dispatch({ type: 'focus', target: String(targetId) }, { source: 'keyboard' });
         }
         break;
       }
@@ -172,8 +171,7 @@ export class KeybindingManager {
         const delta = action === 'FocusNextPane' ? 1 : -1;
         const next = rowPanes[(idx + delta + rowPanes.length) % rowPanes.length];
         if (next) {
-          sessionManager.setActivePane(next.id);
-          waterfallArea.scrollToPane(next.id);
+          void workspaceActions.dispatch({ type: 'focus', target: String(next.id) }, { source: 'keyboard' });
         }
         break;
       }
@@ -187,7 +185,13 @@ export class KeybindingManager {
         const pane = waterfallArea.getActivePane();
         if (!pane) break;
         const group = prompt('Set group:', pane.getInfo().group);
-        if (group !== null) sessionManager.setPaneGroup(pane.paneId, group.trim() || 'default');
+        if (group !== null) {
+          void workspaceActions.dispatch({
+            type: 'group',
+            target: String(pane.paneId),
+            group: group.trim() || 'default',
+          }, { source: 'keyboard' });
+        }
         break;
       }
       case 'IncreaseFontSize':
@@ -205,7 +209,11 @@ export class KeybindingManager {
           if (!text) return;
           const activeId = sessionManager.getActivePaneId();
           if (activeId == null) return;
-          invoke('pty_write', { args: { pane_id: activeId, data: text } }).catch(console.error);
+          workspaceActions.dispatch({
+            type: 'paste',
+            target: String(activeId),
+            data: text,
+          }, { source: 'keyboard' }).catch(console.error);
         }).catch(console.error);
         break;
       case 'Quit':

--- a/src/session/AutoNamer.ts
+++ b/src/session/AutoNamer.ts
@@ -203,13 +203,3 @@ export function nameFromCwd(cwd: string): string | null {
   const dir = basename(cwd.replace(/\/$/, ''));
   return dir || null;
 }
-
-// ── Auto-named pane tracking ──────────────────────────────────────────────────
-// Panes in this set have names managed by AutoNamer.
-// Removed when the user manually renames a pane.
-
-const autoNamedPanes = new Set<number>();
-
-export function markAutoNamed(paneId: number)   { autoNamedPanes.add(paneId); }
-export function unmarkAutoNamed(paneId: number) { autoNamedPanes.delete(paneId); }
-export function isAutoNamed(paneId: number)     { return autoNamedPanes.has(paneId); }

--- a/src/session/PaneNamingPolicy.ts
+++ b/src/session/PaneNamingPolicy.ts
@@ -1,0 +1,19 @@
+import type { PaneInfo } from './types';
+import { isSignificantCommand, nameFromCwd, suggestName } from './AutoNamer';
+
+export function canAutoRenamePane(pane: PaneInfo): boolean {
+  return pane.name_source === 'auto';
+}
+
+export function suggestCwdNameForPane(pane: PaneInfo): string | null {
+  if (!canAutoRenamePane(pane)) return null;
+  const nextName = nameFromCwd(pane.cwd);
+  return nextName && nextName !== pane.name ? nextName : null;
+}
+
+export function suggestCommandNameForPane(pane: PaneInfo, command: string): string | null {
+  const trimmed = command.trim();
+  if (!trimmed || !isSignificantCommand(trimmed) || !canAutoRenamePane(pane)) return null;
+  const nextName = suggestName(trimmed, pane.cwd);
+  return nextName && nextName !== pane.name ? nextName : null;
+}

--- a/src/session/SessionManager.ts
+++ b/src/session/SessionManager.ts
@@ -1,6 +1,5 @@
-import { invoke } from '@tauri-apps/api/core';
-import { listen } from '@tauri-apps/api/event';
-import type { PaneInfo, AgentType, SessionStatus } from './types';
+import { transport } from '../transport';
+import type { PaneInfo, AgentType, SessionStatus, PaneNameSource } from './types';
 
 type SessionListener = (panes: PaneInfo[], activePaneId: number | null) => void;
 type ActivePaneListener = (paneId: number) => void;
@@ -13,19 +12,19 @@ class SessionManager {
 
   async init() {
     // Load initial state
-    const result = await invoke<{ panes: PaneInfo[]; active_pane_id: number | null }>('session_list');
+    const result = await transport.send<{ panes: PaneInfo[]; active_pane_id: number | null }>('session_list');
     this.panes = new Map(result.panes.map(p => [p.id, p]));
     this.activePaneId = result.active_pane_id;
 
     // Subscribe to backend events
-    await listen<PaneInfo[]>('session:changed', (event) => {
-      this.panes = new Map(event.payload.map(p => [p.id, p]));
+    await transport.listen<PaneInfo[]>('session:changed', (panes) => {
+      this.panes = new Map(panes.map(p => [p.id, p]));
       this.notifyListeners();
     });
 
-    await listen<number>('session:active_changed', (event) => {
-      this.activePaneId = event.payload;
-      this.notifyActiveListeners(event.payload);
+    await transport.listen<number>('session:active_changed', (paneId) => {
+      this.activePaneId = paneId;
+      this.notifyActiveListeners(paneId);
     });
   }
 
@@ -67,27 +66,27 @@ class SessionManager {
   async setActivePane(id: number) {
     this.activePaneId = id;
     this.notifyActiveListeners(id);
-    await invoke('session_set_active', { paneId: id });
+    await transport.send('session_set_active', { paneId: id });
   }
 
-  async renamePane(id: number, name: string) {
-    await invoke('session_rename', { paneId: id, name });
+  async renamePane(id: number, name: string, nameSource: PaneNameSource = 'manual') {
+    await transport.send('session_rename', { paneId: id, name, nameSource });
   }
 
   async setPaneGroup(id: number, group: string) {
-    await invoke('session_set_group', { paneId: id, group });
+    await transport.send('session_set_group', { paneId: id, group });
   }
 
   async setPaneAgent(id: number, agentType: AgentType) {
-    await invoke('session_set_agent', { paneId: id, agentType });
+    await transport.send('session_set_agent', { paneId: id, agentType });
   }
 
   async setPaneStatus(id: number, status: SessionStatus) {
-    await invoke('session_set_status', { paneId: id, status });
+    await transport.send('session_set_status', { paneId: id, status });
   }
 
   async setPaneNote(id: number, note: string) {
-    await invoke('session_set_note', { paneId: id, note });
+    await transport.send('session_set_note', { paneId: id, note });
   }
 
   getRowPanes(rowIndex: number): PaneInfo[] {
@@ -109,7 +108,7 @@ class SessionManager {
   }
 
   scrollToPane(_id: number) {
-    // Implemented by WaterfallArea via setWaterfallArea in ai-handler
+    // Viewport scrolling is exposed through WorkspaceActions ports.
   }
 }
 

--- a/src/session/SessionObserver.ts
+++ b/src/session/SessionObserver.ts
@@ -1,0 +1,68 @@
+import { agentDetector } from '../input/AgentDetector';
+import { sessionManager } from './SessionManager';
+import { suggestCommandNameForPane, suggestCwdNameForPane } from './PaneNamingPolicy';
+import type { PaneInfo } from './types';
+
+class SessionObserver {
+  private initialized = false;
+  private previousCwd: Map<number, string> = new Map();
+  private observedAgentPanes: Set<number> = new Set();
+
+  init() {
+    if (this.initialized) return;
+    this.initialized = true;
+
+    sessionManager.onChange((panes) => this.handlePanes(panes));
+    this.handlePanes(sessionManager.getAllPanes());
+
+    document.addEventListener('insert-command-submitted', (event: Event) => {
+      const { text, paneId } = (event as CustomEvent<{ text: string; paneId: number }>).detail;
+      const pane = sessionManager.getPane(paneId);
+      if (!pane) return;
+      const nextName = suggestCommandNameForPane(pane, text);
+      if (nextName) {
+        void sessionManager.renamePane(paneId, nextName, 'auto');
+      }
+    });
+  }
+
+  private observeAgent(paneId: number) {
+    if (this.observedAgentPanes.has(paneId)) return;
+    this.observedAgentPanes.add(paneId);
+    agentDetector.onAgentChange(paneId, (agent) => {
+      void sessionManager.setPaneAgent(paneId, agent);
+    });
+  }
+
+  private handlePanes(panes: PaneInfo[]) {
+    const livePaneIds = new Set(panes.map(pane => pane.id));
+
+    for (const id of this.previousCwd.keys()) {
+      if (!livePaneIds.has(id)) this.previousCwd.delete(id);
+    }
+    for (const id of this.observedAgentPanes) {
+      if (!livePaneIds.has(id)) {
+        this.observedAgentPanes.delete(id);
+        agentDetector.clearPane(id);
+      }
+    }
+
+    for (const pane of panes) {
+      this.observeAgent(pane.id);
+
+      const previous = this.previousCwd.get(pane.id);
+      this.previousCwd.set(pane.id, pane.cwd);
+
+      const shouldNameInitialPane = previous === undefined;
+      const cwdChanged = previous !== undefined && previous !== pane.cwd;
+      if (shouldNameInitialPane || cwdChanged) {
+        const nextName = suggestCwdNameForPane(pane);
+        if (nextName) {
+          void sessionManager.renamePane(pane.id, nextName, 'auto');
+        }
+      }
+    }
+  }
+}
+
+export const sessionObserver = new SessionObserver();

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -2,6 +2,8 @@ export type SessionStatus = 'idle' | 'running' | 'error';
 
 export type AgentType = 'none' | 'claude' | 'codex' | 'aider' | 'unknown';
 
+export type PaneNameSource = 'auto' | 'manual';
+
 export interface PaneInfo {
   id: number;
   name: string;
@@ -9,10 +11,16 @@ export interface PaneInfo {
   note: string;
   status: SessionStatus;
   cwd: string;
-  pty_pid: number;
+  name_source: PaneNameSource;
   agent_type: AgentType;
   row_index: number;
   pane_index: number;
+  /** Last command submitted to the shell (from OSC 133;B). Null until first command runs. */
+  last_command: string | null;
+  /** Exit code of the last completed command (from OSC 133;D). Null until first command completes. */
+  last_exit_code: number | null;
+  /** Whether the pane is currently in alternate screen mode (e.g. vim, htop). */
+  alternate_screen: boolean;
 }
 
 export interface RowInfo {

--- a/src/settings/SettingsPanel.ts
+++ b/src/settings/SettingsPanel.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { transport } from '../transport';
 import { configContext } from '../config/ConfigContext';
 import { llmClient } from '../ai/llm-client';
 import { hintManager } from '../hints/HintManager';
@@ -142,11 +142,12 @@ function kbLabel(key: string, mods: string | undefined): string {
 }
 
 const KNOWN_PROVIDERS = [
-  '',             // auto-detect from model name
   'anthropic',
   'openai',
   'google',
   'ollama',
+  'lmstudio',
+  'openrouter',
   'claude-cli',
 ];
 
@@ -154,19 +155,16 @@ const KNOWN_MODELS = [
   'none',
   'claude-cli',
   // Anthropic
-  'claude-opus-4-6',
-  'claude-sonnet-4-6',
-  'claude-haiku-4-5-20251001',
+  'anthropic/claude-sonnet-4-5',
+  'anthropic/claude-opus-4-1',
+  'anthropic/claude-haiku-4-5',
   // OpenAI
-  'gpt-4o',
-  'gpt-4o-mini',
-  'o1',
-  'o3-mini',
-  'o4-mini',
+  'openai/gpt-5',
+  'openai/gpt-5-mini',
+  'openai/gpt-4o',
   // Google
-  'gemini-2.0-flash',
-  'gemini-2.5-pro',
-  'gemini-1.5-pro',
+  'google/gemini-2.5-pro',
+  'google/gemini-2.5-flash',
   // Ollama (common local models)
   'ollama/llama3',
   'ollama/llama3.1',
@@ -174,7 +172,50 @@ const KNOWN_MODELS = [
   'ollama/qwen2.5',
   'ollama/deepseek-r1',
   'ollama/phi4',
+  // OpenAI-compatible examples
+  'lmstudio/google/gemma-3n-e4b',
+  'openrouter/anthropic/claude-sonnet-4.5',
 ];
+
+function ensureAiProviderMap(wai: any): Record<string, any> {
+  if (!wai.provider || typeof wai.provider === 'string') {
+    const legacy = typeof wai.provider === 'string' ? wai.provider.trim() : '';
+    wai.provider = {};
+    if (legacy) wai.provider[legacy] = { options: {}, models: {} };
+  }
+  return wai.provider;
+}
+
+function splitOpenCodeModelId(model: string, providers: Record<string, any>): { providerId: string; modelKey: string } {
+  const trimmed = model.trim();
+  const slash = trimmed.indexOf('/');
+  if (slash > 0) {
+    return { providerId: trimmed.slice(0, slash), modelKey: trimmed.slice(slash + 1) };
+  }
+  const inferred = trimmed.startsWith('claude-') ? 'anthropic'
+    : trimmed.startsWith('gpt-') || trimmed.startsWith('o') ? 'openai'
+      : trimmed.startsWith('gemini-') ? 'google'
+        : Object.keys(providers)[0] ?? 'openai';
+  return { providerId: inferred, modelKey: trimmed };
+}
+
+function stringifyJsonObject(value: unknown): string {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return '{}';
+  return JSON.stringify(value, null, 2);
+}
+
+function parseJsonObject(text: string): Record<string, unknown> | null {
+  const trimmed = text.trim();
+  if (!trimmed) return {};
+  try {
+    const parsed = JSON.parse(trimmed);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
 
 const WORKSPACE_SCROLL_MODIFIER_OPTIONS = [
   { value: 'meta', label: 'Command' },
@@ -679,7 +720,7 @@ const SECTIONS: Section[] = [
       {
         label: 'Persistence',
         fields: [
-          { path: 'persistence.keep_alive',              label: 'Keep alive',              type: 'checkbox', desc: 'PTYs keep running after window close' },
+          { path: 'persistence.restore_workspace_on_launch', label: 'Restore workspace on launch', type: 'checkbox', desc: 'Restore session layout when the app is reopened' },
           { path: 'persistence.tray_icon',               label: 'Tray icon',               type: 'checkbox' },
           { path: 'persistence.disk_state_path',         label: 'State file path',         type: 'text' },
           { path: 'persistence.scrollback_lines',        label: 'Scrollback lines saved',  type: 'number', min: 0, max: 100000, step: 500 },
@@ -983,17 +1024,30 @@ const SECTIONS: Section[] = [
             const model: string = wai.model ?? 'none';
             const isNone = !model || model === 'none';
             const isCli = model === 'claude-cli';
-            const needsKey = !isNone && !isCli;
+            const providers = ensureAiProviderMap(wai);
+            const { providerId, modelKey } = splitOpenCodeModelId(model, providers);
+            if (!isNone && !isCli && !providers[providerId]) {
+              providers[providerId] = { options: {}, models: {} };
+            }
+            const providerCfg = providers[providerId] ?? { options: {}, models: {} };
+            providerCfg.options ??= {};
+            providerCfg.models ??= {};
+            const modelCfg = providerCfg.models[modelKey] ?? { options: {} };
+            modelCfg.options ??= {};
+            if (!isNone && !isCli) {
+              providers[providerId] = providerCfg;
+              providerCfg.models[modelKey] = modelCfg;
+            }
 
             // ── Model ────────────────────────────────────────────────────
             const modelRow = document.createElement('div');
             modelRow.className = 'st-field';
             const modelLabel = document.createElement('label');
             modelLabel.className = 'st-label';
-            modelLabel.textContent = 'Model';
+            modelLabel.textContent = 'Model ID';
             const modelDesc = document.createElement('span');
             modelDesc.className = 'st-desc';
-            modelDesc.textContent = 'claude-sonnet-4-6 · gpt-4o · gemini-2.0-flash · ollama/llama3 · claude-cli';
+            modelDesc.textContent = 'OpenCode-style provider/model, for example anthropic/claude-sonnet-4-5 or openai/gpt-5';
             modelLabel.appendChild(modelDesc);
             modelRow.appendChild(modelLabel);
 
@@ -1020,66 +1074,93 @@ const SECTIONS: Section[] = [
             el.appendChild(modelRow);
 
             if (isCli) {
-              // claude-cli note
               const note = document.createElement('div');
               note.className = 'st-field st-info-note';
               note.textContent = 'claude-cli runs the `claude` CLI installed on your system. No API key needed — uses your existing Claude Code login.';
               el.appendChild(note);
             }
 
-            // ── Provider (hidden for claude-cli / none) ───────────────
             if (!isNone && !isCli) {
-              const provRow = document.createElement('div');
-              provRow.className = 'st-field';
-              const provLabel = document.createElement('label');
-              provLabel.className = 'st-label';
-              provLabel.textContent = 'Provider';
-              const provDesc = document.createElement('span');
-              provDesc.className = 'st-desc';
-              provDesc.textContent = 'Leave blank to auto-detect (claude-* → anthropic, gpt-* → openai, etc.)';
-              provLabel.appendChild(provDesc);
-              provRow.appendChild(provLabel);
-              const provSel = document.createElement('select');
-              provSel.className = 'st-input';
-              for (const p of KNOWN_PROVIDERS.filter(p => p !== 'claude-cli')) {
-                const o = document.createElement('option');
-                o.value = p;
-                o.textContent = p || '(auto-detect)';
-                if ((wai.provider ?? '') === p) o.selected = true;
-                provSel.appendChild(o);
-              }
-              provSel.addEventListener('change', () => {
-                wai.provider = provSel.value || null;
+              const smallRow = document.createElement('div');
+              smallRow.className = 'st-field';
+              const smallLabel = document.createElement('label');
+              smallLabel.className = 'st-label';
+              smallLabel.textContent = 'Small model';
+              const smallDesc = document.createElement('span');
+              smallDesc.className = 'st-desc';
+              smallDesc.textContent = 'Optional provider/model for cheap background tasks';
+              smallLabel.appendChild(smallDesc);
+              smallRow.appendChild(smallLabel);
+              const smallInp = document.createElement('input');
+              smallInp.type = 'text';
+              smallInp.className = 'st-input';
+              smallInp.value = wai.small_model ?? '';
+              smallInp.setAttribute('list', listId);
+              smallInp.placeholder = 'anthropic/claude-haiku-4-5';
+              smallInp.addEventListener('change', () => {
+                wai.small_model = smallInp.value.trim() || null;
                 dirty();
               });
-              provRow.appendChild(provSel);
-              el.appendChild(provRow);
-            }
+              smallRow.appendChild(smallInp);
+              el.appendChild(smallRow);
 
-            // ── API key env var (hidden for claude-cli / none) ────────
-            if (needsKey) {
+              const providerRow = document.createElement('div');
+              providerRow.className = 'st-field';
+              const providerLabel = document.createElement('label');
+              providerLabel.className = 'st-label';
+              providerLabel.textContent = 'Provider';
+              const providerDesc = document.createElement('span');
+              providerDesc.className = 'st-desc';
+              providerDesc.textContent = 'provider entry used by this model ID';
+              providerLabel.appendChild(providerDesc);
+              providerRow.appendChild(providerLabel);
+              const providerInp = document.createElement('input');
+              providerInp.type = 'text';
+              providerInp.className = 'st-input';
+              providerInp.value = providerId;
+              providerInp.setAttribute('list', 'st-dl-provider');
+              const providerList = document.createElement('datalist');
+              providerList.id = 'st-dl-provider';
+              for (const p of KNOWN_PROVIDERS) {
+                const o = document.createElement('option');
+                o.value = p;
+                providerList.appendChild(o);
+              }
+              providerInp.addEventListener('change', () => {
+                const nextProviderId = providerInp.value.trim();
+                if (!nextProviderId || nextProviderId === providerId) return;
+                providers[nextProviderId] = providers[providerId] ?? { options: {}, models: {} };
+                delete providers[providerId];
+                wai.model = `${nextProviderId}/${modelKey}`;
+                dirty();
+                rebuild();
+              });
+              providerRow.appendChild(providerInp);
+              providerRow.appendChild(providerList);
+              el.appendChild(providerRow);
+
               const keyRow = document.createElement('div');
               keyRow.className = 'st-field';
               const keyLabel = document.createElement('label');
               keyLabel.className = 'st-label';
-              keyLabel.textContent = 'API key env var';
+              keyLabel.textContent = 'API key';
               const keyDesc = document.createElement('span');
               keyDesc.className = 'st-desc';
-              keyDesc.textContent = 'Environment variable holding your API key (e.g. ANTHROPIC_API_KEY, OPENAI_API_KEY)';
+              keyDesc.textContent = 'Use {env:ANTHROPIC_API_KEY} or {file:~/.config/provider-key}';
               keyLabel.appendChild(keyDesc);
               keyRow.appendChild(keyLabel);
               const keyInp = document.createElement('input');
               keyInp.type = 'text';
               keyInp.className = 'st-input';
-              keyInp.value = wai.api_key_env ?? '';
-              keyInp.placeholder = 'ANTHROPIC_API_KEY';
-              keyInp.addEventListener('input', () => { wai.api_key_env = keyInp.value; dirty(); });
+              keyInp.value = String(providerCfg.options.apiKey ?? '');
+              keyInp.placeholder = providerId === 'openai' ? '{env:OPENAI_API_KEY}' : '{env:ANTHROPIC_API_KEY}';
+              keyInp.addEventListener('input', () => {
+                providerCfg.options.apiKey = keyInp.value.trim();
+                dirty();
+              });
               keyRow.appendChild(keyInp);
               el.appendChild(keyRow);
-            }
 
-            // ── Base URL (hidden for claude-cli / none) ────────────────
-            if (!isNone && !isCli) {
               const urlRow = document.createElement('div');
               urlRow.className = 'st-field';
               const urlLabel = document.createElement('label');
@@ -1087,17 +1168,70 @@ const SECTIONS: Section[] = [
               urlLabel.textContent = 'Base URL';
               const urlDesc = document.createElement('span');
               urlDesc.className = 'st-desc';
-              urlDesc.textContent = 'Override API endpoint — required for Ollama (http://localhost:11434) or OpenAI-compatible servers';
+              urlDesc.textContent = 'OpenAI-compatible providers can use their own endpoint';
               urlLabel.appendChild(urlDesc);
               urlRow.appendChild(urlLabel);
               const urlInp = document.createElement('input');
               urlInp.type = 'text';
               urlInp.className = 'st-input';
-              urlInp.value = wai.base_url ?? '';
-              urlInp.placeholder = 'http://localhost:11434';
-              urlInp.addEventListener('input', () => { wai.base_url = urlInp.value || null; dirty(); });
+              urlInp.value = String(providerCfg.options.baseURL ?? '');
+              urlInp.placeholder = providerId === 'ollama' ? 'http://localhost:11434' : 'https://api.openai.com';
+              urlInp.addEventListener('input', () => {
+                if (urlInp.value.trim()) providerCfg.options.baseURL = urlInp.value.trim();
+                else delete providerCfg.options.baseURL;
+                dirty();
+              });
               urlRow.appendChild(urlInp);
               el.appendChild(urlRow);
+
+              const upstreamRow = document.createElement('div');
+              upstreamRow.className = 'st-field';
+              const upstreamLabel = document.createElement('label');
+              upstreamLabel.className = 'st-label';
+              upstreamLabel.textContent = 'Model alias';
+              const upstreamDesc = document.createElement('span');
+              upstreamDesc.className = 'st-desc';
+              upstreamDesc.textContent = 'Optional upstream id; leave empty to use the model key from provider/model';
+              upstreamLabel.appendChild(upstreamDesc);
+              upstreamRow.appendChild(upstreamLabel);
+              const upstreamInp = document.createElement('input');
+              upstreamInp.type = 'text';
+              upstreamInp.className = 'st-input';
+              upstreamInp.value = modelCfg.id ?? '';
+              upstreamInp.placeholder = modelKey;
+              upstreamInp.addEventListener('input', () => {
+                modelCfg.id = upstreamInp.value.trim() || null;
+                dirty();
+              });
+              upstreamRow.appendChild(upstreamInp);
+              el.appendChild(upstreamRow);
+
+              const optionsRow = document.createElement('div');
+              optionsRow.className = 'st-field';
+              const optionsLabel = document.createElement('label');
+              optionsLabel.className = 'st-label';
+              optionsLabel.textContent = 'Model options';
+              const optionsDesc = document.createElement('span');
+              optionsDesc.className = 'st-desc';
+              optionsDesc.textContent = 'JSON object, for example {"reasoningEffort":"high","maxTokens":2048}';
+              optionsLabel.appendChild(optionsDesc);
+              optionsRow.appendChild(optionsLabel);
+              const optionsInp = document.createElement('textarea');
+              optionsInp.className = 'st-input';
+              optionsInp.rows = 5;
+              optionsInp.value = stringifyJsonObject(modelCfg.options);
+              optionsInp.addEventListener('change', () => {
+                const parsed = parseJsonObject(optionsInp.value);
+                if (!parsed) {
+                  optionsInp.classList.add('error');
+                  return;
+                }
+                optionsInp.classList.remove('error');
+                modelCfg.options = parsed;
+                dirty();
+              });
+              optionsRow.appendChild(optionsInp);
+              el.appendChild(optionsRow);
             }
 
             // ── Test button ────────────────────────────────────────────
@@ -1514,7 +1648,7 @@ export class SettingsPanel {
 
   private async save() {
     try {
-      await invoke('config_save', { cfg: this.cfg });
+      await transport.send('config_save', { cfg: this.cfg });
       this.hasUnsavedPreview = false;
       this.hide();
     } catch (e: any) {

--- a/src/sidebar/SessionSidebar.ts
+++ b/src/sidebar/SessionSidebar.ts
@@ -1,10 +1,9 @@
 import type { PaneInfo } from '../session/types';
 import { sessionManager } from '../session/SessionManager';
-import type { WaterfallArea } from '../waterfall/WaterfallArea';
+import { workspaceActions } from '../workspace/WorkspaceActions';
 
 export class SessionSidebar {
   readonly el: HTMLElement;
-  private waterfallArea: WaterfallArea | null = null;
   private visible = false;
 
   constructor() {
@@ -14,10 +13,6 @@ export class SessionSidebar {
     sessionManager.onChange((panes, activePaneId) => {
       this.render(panes, activePaneId);
     });
-  }
-
-  setWaterfallArea(area: WaterfallArea) {
-    this.waterfallArea = area;
   }
 
   toggle() {
@@ -63,8 +58,7 @@ export class SessionSidebar {
     this.el.querySelectorAll('.sb-item').forEach(item => {
       item.addEventListener('click', () => {
         const id = parseInt((item as HTMLElement).dataset.id || '0');
-        sessionManager.setActivePane(id);
-        this.waterfallArea?.scrollToPane(id);
+        void workspaceActions.dispatch({ type: 'focus', target: String(id) }, { source: 'ui' });
       });
     });
 
@@ -72,7 +66,7 @@ export class SessionSidebar {
       btn.addEventListener('click', (e) => {
         e.stopPropagation();
         const id = parseInt((btn as HTMLElement).dataset.closeId || '0');
-        this.waterfallArea?.getPane(id)?.destroy();
+        void workspaceActions.dispatch({ type: 'close', target: String(id) }, { source: 'ui' });
       });
     });
   }

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -1,0 +1,17 @@
+import { invoke, type InvokeArgs } from '@tauri-apps/api/core';
+import { listen as tauriListen, type UnlistenFn } from '@tauri-apps/api/event';
+
+export interface Transport {
+  send<T>(cmd: string, args?: InvokeArgs): Promise<T>;
+  listen<T>(event: string, handler: (payload: T) => void): Promise<UnlistenFn>;
+}
+
+export const transport: Transport = {
+  send<T>(cmd: string, args?: InvokeArgs): Promise<T> {
+    return invoke<T>(cmd, args);
+  },
+
+  listen<T>(event: string, handler: (payload: T) => void): Promise<UnlistenFn> {
+    return tauriListen<T>(event, (eventPayload) => handler(eventPayload.payload));
+  },
+};

--- a/src/waterfall/TerminalPane.ts
+++ b/src/waterfall/TerminalPane.ts
@@ -1,19 +1,19 @@
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
-import { invoke } from '@tauri-apps/api/core';
-import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import type { PaneInfo } from '../session/types';
+import { transport } from '../transport';
 import { configContext } from '../config/ConfigContext';
 import { sessionManager } from '../session/SessionManager';
 import { agentDetector } from '../input/AgentDetector';
 import { modeManager } from '../input/ModeManager';
-import { unmarkAutoNamed } from '../session/AutoNamer';
 import { hintManager } from '../hints/HintManager';
+import { workspaceActions } from '../workspace/WorkspaceActions';
 
 // ── Module-level floating context menu (one singleton shared across panes) ──
 let _ctxMenu: HTMLElement | null = null;
 type WorkspaceScrollModifier = 'meta' | 'control' | 'alt' | 'shift' | 'disabled';
+type UnlistenFn = () => void;
 
 function getCtxMenu(): HTMLElement {
   if (!_ctxMenu) {
@@ -107,7 +107,7 @@ export class TerminalPane {
 
     // Handle user input → send to PTY
     this.term.onData((data) => {
-      invoke('pty_write', { args: { pane_id: this.paneId, data } }).catch(console.error);
+      transport.send('pty_write', { args: { pane_id: this.paneId, data } }).catch(console.error);
     });
 
     // Handle resize
@@ -136,7 +136,7 @@ export class TerminalPane {
 
     // Close button
     this.el.querySelector('.pane-close')?.addEventListener('click', () => {
-      this.destroy();
+      void workspaceActions.dispatch({ type: 'close', target: String(this.paneId) }, { source: 'ui' });
     });
 
     // Click on pane header → set active only (no mode change).
@@ -145,7 +145,7 @@ export class TerminalPane {
     this.el.addEventListener('mousedown', (e) => {
       const target = e.target as HTMLElement;
       if (target.closest('.pane-close')) return;
-      sessionManager.setActivePane(this.paneId);
+      void workspaceActions.dispatch({ type: 'focus', target: String(this.paneId) }, { source: 'ui' });
       if (!target.closest('.pane-header')) {
         modeManager.enterTerminal(this.paneId);
       }
@@ -189,11 +189,16 @@ export class TerminalPane {
       showCtxMenu(e.clientX, e.clientY, [
         {
           label: 'Enter Insert Mode',
-          action: () => { sessionManager.setActivePane(this.paneId); modeManager.enterInsert(); },
+          action: () => {
+            void workspaceActions.dispatch({ type: 'focus', target: String(this.paneId) }, { source: 'ui' });
+            modeManager.enterInsert();
+          },
         },
         {
           label: 'Split Row',
-          action: () => document.dispatchEvent(new CustomEvent('workspace-action', { detail: 'SplitHorizontal' })),
+          action: () => {
+            void workspaceActions.dispatch({ type: 'split' }, { source: 'ui' });
+          },
         },
         {
           label: 'Rename…',
@@ -203,7 +208,13 @@ export class TerminalPane {
           },
         },
         { label: 'Note…', action: () => document.dispatchEvent(new CustomEvent('open-pane-note')) },
-        { label: 'Close', action: () => this.destroy(), danger: true },
+        {
+          label: 'Close',
+          action: () => {
+            void workspaceActions.dispatch({ type: 'close', target: String(this.paneId) }, { source: 'ui' });
+          },
+          danger: true,
+        },
       ]);
     });
     (el.querySelector('.pane-group-badge') as HTMLElement).textContent =
@@ -225,10 +236,10 @@ export class TerminalPane {
     // Register both listeners in parallel so a fast-exiting PTY can't fire
     // pty-closed before the listener is registered.
     const [unlistenData, unlistenClose] = await Promise.all([
-      listen<{ pane_id: number; data: string }>(
+      transport.listen<{ pane_id: number; data: string }>(
         `pty-data-${this.paneId}`,
-        (event) => {
-          const data = event.payload.data;
+        (payload) => {
+          const data = payload.data;
           this.term.write(data);
           // Feed to agent detector
           agentDetector.addOutput(this.paneId, data);
@@ -255,7 +266,7 @@ export class TerminalPane {
           }
         }
       ),
-      listen(`pty-closed-${this.paneId}`, () => {
+      transport.listen(`pty-closed-${this.paneId}`, () => {
         this.term.write('\r\n\x1b[33m[Process exited]\x1b[0m\r\n');
         setTimeout(() => this.destroy(), 300);
       }),
@@ -263,12 +274,6 @@ export class TerminalPane {
 
     this.unlisten = unlistenData;
     this.unlistenClose = unlistenClose;
-
-    // When agent is detected, update session info.
-    // InputBar refreshes automatically via sessionManager.onChange listener.
-    agentDetector.onAgentChange(this.paneId, (agent) => {
-      sessionManager.setPaneAgent(this.paneId, agent);
-    });
   }
 
   /** Begin inline rename on the pane name element. */
@@ -290,8 +295,11 @@ export class TerminalPane {
       nameEl.contentEditable = 'false';
       nameEl.classList.remove('renaming');
       if (newName && newName !== original) {
-        sessionManager.renamePane(this.paneId, newName);
-        unmarkAutoNamed(this.paneId);
+        void workspaceActions.dispatch({
+          type: 'rename',
+          target: String(this.paneId),
+          name: newName,
+        }, { source: 'ui' });
       } else {
         nameEl.textContent = original; // revert if empty or unchanged
       }
@@ -361,14 +369,14 @@ export class TerminalPane {
 
   // Write data directly to PTY (for Workspace AI dispatch)
   async writeCommand(cmd: string) {
-    await invoke('pty_write', { args: { pane_id: this.paneId, data: cmd + '\r' } });
+    await transport.send('pty_write', { args: { pane_id: this.paneId, data: cmd + '\r' } });
   }
 
   fit() {
     try {
       this.fitAddon.fit();
       const { cols, rows } = this.term;
-      invoke('pty_resize', { args: { pane_id: this.paneId, cols, rows } }).catch(console.error);
+      transport.send('pty_resize', { args: { pane_id: this.paneId, cols, rows } }).catch(console.error);
     } catch (_) {}
   }
 
@@ -380,7 +388,7 @@ export class TerminalPane {
     this.term.options.fontSize = size;
     this.fitAddon.fit();
     const { cols, rows } = this.term;
-    invoke('pty_resize', { args: { pane_id: this.paneId, cols, rows } }).catch(console.error);
+    transport.send('pty_resize', { args: { pane_id: this.paneId, cols, rows } }).catch(console.error);
   }
 
   async destroy() {
@@ -393,7 +401,7 @@ export class TerminalPane {
     this.term.dispose();
     const prevRow = this.el.parentElement as HTMLElement | null;  // capture before removal
     this.el.remove();
-    await invoke('pty_kill', { paneId: this.paneId });
+    await transport.send('pty_kill', { paneId: this.paneId });
     this.onClose(this.paneId, prevRow);
   }
 
@@ -542,7 +550,7 @@ export class TerminalPane {
         if (lines === 0) return false;
         const seq = deltaPixels > 0 ? '\x1b[B' : '\x1b[A'; // arrow down / up
         for (let i = 0; i < lines; i++) {
-          invoke('pty_write', { args: { pane_id: this.paneId, data: seq } }).catch(console.error);
+          transport.send('pty_write', { args: { pane_id: this.paneId, data: seq } }).catch(console.error);
         }
         return false;
       }

--- a/src/waterfall/TerminalPane.ts
+++ b/src/waterfall/TerminalPane.ts
@@ -260,7 +260,8 @@ export class TerminalPane {
               data.includes('\x1b[?47l');
             if (entersAltScreen && modeManager.isInShellMode()) {
               modeManager.enterTerminal(this.paneId);
-            } else if (leavesAltScreen && modeManager.isInPaneMode()) {
+            }
+            if (leavesAltScreen && modeManager.isInPaneMode()) {
               modeManager.enterInsert();
             }
           }

--- a/src/waterfall/WaterfallArea.ts
+++ b/src/waterfall/WaterfallArea.ts
@@ -1,9 +1,8 @@
-import { invoke } from '@tauri-apps/api/core';
+import { transport } from '../transport';
 import { TerminalPane } from './TerminalPane';
 import { sessionManager } from '../session/SessionManager';
 import { modeManager } from '../input/ModeManager';
 import { configContext } from '../config/ConfigContext';
-import { nameFromCwd, isDefaultName, markAutoNamed, isAutoNamed } from '../session/AutoNamer';
 import { hintManager } from '../hints/HintManager';
 
 const DEFAULT_WATERFALL_ROW_GAP = 5;
@@ -24,7 +23,6 @@ export class WaterfallArea {
   private layoutObserver: ResizeObserver;
   private scrollSettleTimer: ReturnType<typeof setTimeout> | null = null;
   private nextPaneId = 1;
-  private prevCwd: Map<number, string> = new Map();
   private lastPointerPos: { x: number; y: number } | null = null;
 
   constructor(container: HTMLElement) {
@@ -35,20 +33,13 @@ export class WaterfallArea {
     this.layoutObserver.observe(this.el);
     this.el.addEventListener('scroll', () => this.scheduleEdgeSettle(), { passive: true });
 
-    // React to session changes — also detect cwd changes for auto-renaming
+    // React to session changes. Business policies such as auto-renaming live
+    // in SessionObserver so this component stays focused on layout/rendering.
     sessionManager.onChange((panes, activePaneId) => {
       for (const pane of this.panes.values()) {
         const info = panes.find(p => p.id === pane.paneId);
         if (info) {
           pane.updateInfo(info);
-
-          // If cwd changed and this pane is auto-named, update name to new dir
-          const prev = this.prevCwd.get(info.id);
-          if (prev !== undefined && prev !== info.cwd && isAutoNamed(info.id)) {
-            const newName = nameFromCwd(info.cwd);
-            if (newName) sessionManager.renamePane(info.id, newName);
-          }
-          this.prevCwd.set(info.id, info.cwd);
         }
         pane.setActive(pane.paneId === activePaneId);
       }
@@ -574,7 +565,7 @@ export class WaterfallArea {
     );
 
     try {
-      await invoke('pty_spawn', {
+      await transport.send('pty_spawn', {
         args: {
           pane_id: paneId,
           cwd: inheritedCwd || null,
@@ -598,10 +589,13 @@ export class WaterfallArea {
       note: '',
       status: 'idle' as const,
       cwd: opts.cwd || '~',
-      pty_pid: 0,
+      name_source: 'auto' as const,
       agent_type: 'none' as const,
       row_index: targetRowIndex,
       pane_index: 0,
+      last_command: null,
+      last_exit_code: null,
+      alternate_screen: false,
     };
 
     const pane = new TerminalPane(info, (id, prevRow) => this.handlePaneClose(id, prevRow));
@@ -642,18 +636,6 @@ export class WaterfallArea {
       if (modeManager.getMode().type === 'insert') {
         document.dispatchEvent(new CustomEvent('focus-inputbar'));
       }
-      // Auto-name from cwd if still on default name
-      const spawned = sessionManager.getPane(paneId);
-      if (spawned) {
-        this.prevCwd.set(paneId, spawned.cwd);
-        if (isDefaultName(spawned.name)) {
-          const cwdName = nameFromCwd(spawned.cwd);
-          if (cwdName) {
-            sessionManager.renamePane(paneId, cwdName);
-            markAutoNamed(paneId);
-          }
-        }
-      }
     });
 
     setTimeout(() => {
@@ -667,7 +649,6 @@ export class WaterfallArea {
     const fallback = this.pickFallbackPane(id, prevRow);
 
     this.panes.delete(id);
-    this.prevCwd.delete(id);
     // Remove empty rows; sync resize handles on rows that still have panes
     this.rowEls = this.rowEls.filter(row => {
       const termPanes = this.getTerminalPanes(row);

--- a/src/workspace/WorkspaceActions.ts
+++ b/src/workspace/WorkspaceActions.ts
@@ -1,0 +1,396 @@
+import { planExecutor } from '../ai/plan-executor';
+import type { PaneInfo, AgentType, SessionStatus } from '../session/types';
+
+export type WorkspaceAction =
+  | { type: 'run'; target: string; cmd: string }
+  | { type: 'broadcast'; cmd: string }
+  | { type: 'run-group'; group: string; cmd: string }
+  | { type: 'sequential'; target: string; cmds: string[] }
+  | { type: 'new'; name?: string | null; group?: string | null }
+  | { type: 'rename'; target: string; name: string }
+  | { type: 'close'; target: string }
+  | { type: 'close-group'; group: string }
+  | { type: 'split' }
+  | { type: 'focus'; target: string }
+  | { type: 'group'; target: string; group: string }
+  | { type: 'note'; target: string; text: string }
+  | { type: 'clear'; target: string }
+  | { type: 'kill'; target: string }
+  | { type: 'write'; target: string; data: string }
+  | { type: 'paste'; target: string; data: string }
+  | { type: 'set-agent'; target: string; agentType: AgentType };
+
+export type WorkspaceActionSource = 'keyboard' | 'ui' | 'ai' | 'system';
+
+export interface WorkspaceActionResult {
+  ok: boolean;
+  message: string;
+  action: WorkspaceAction;
+  error?: string;
+}
+
+export interface ActionLogEntry {
+  id: string;
+  timestamp: number;
+  source: WorkspaceActionSource;
+  action: WorkspaceAction;
+  result?: WorkspaceActionResult;
+}
+
+export interface SessionPort {
+  getAllPanes(): PaneInfo[];
+  getPane(id: number): PaneInfo | undefined;
+  getActivePaneId(): number | null;
+  getActivePane(): PaneInfo | undefined;
+  setActivePane(id: number): Promise<void>;
+  renamePane(id: number, name: string, nameSource?: 'auto' | 'manual'): Promise<void>;
+  setPaneGroup(id: number, group: string): Promise<void>;
+  setPaneAgent(id: number, agentType: AgentType): Promise<void>;
+  setPaneStatus(id: number, status: SessionStatus): Promise<void>;
+  setPaneNote(id: number, note: string): Promise<void>;
+}
+
+export interface TerminalRuntimePort {
+  write(paneId: number, data: string): Promise<void>;
+}
+
+export interface SpawnPaneOptions {
+  newRow: boolean;
+  group?: string;
+  cwd?: string;
+  targetRow?: number;
+  afterPaneId?: number;
+}
+
+export interface PaneRef {
+  paneId: number;
+}
+
+export interface WorkspaceLayoutPort {
+  spawnPane(opts: SpawnPaneOptions): Promise<PaneRef | null>;
+  splitCurrentRow(): void | Promise<void>;
+  closePane(paneId: number): Promise<void>;
+}
+
+export interface WorkspaceViewportPort {
+  scrollToPane(paneId: number): void;
+}
+
+export interface ActionLogPort {
+  log(entry: ActionLogEntry): void;
+}
+
+export interface WorkspaceActionPorts {
+  session: SessionPort;
+  terminal: TerminalRuntimePort;
+  layout: WorkspaceLayoutPort;
+  viewport: WorkspaceViewportPort;
+  log?: ActionLogPort;
+}
+
+interface DispatchOptions {
+  source?: WorkspaceActionSource;
+}
+
+const CONFIRMABLE_TYPES = new Set<WorkspaceAction['type']>(['broadcast', 'run-group', 'close-group', 'sequential']);
+const ACTION_LOG_LIMIT = 200;
+
+class WorkspaceActions {
+  private ports: WorkspaceActionPorts | null = null;
+  private logEntries: ActionLogEntry[] = [];
+  private nextLogId = 1;
+
+  configure(ports: WorkspaceActionPorts) {
+    this.ports = ports;
+  }
+
+  getLog(): ActionLogEntry[] {
+    return [...this.logEntries];
+  }
+
+  actionDescription(action: WorkspaceAction): string {
+    switch (action.type) {
+      case 'run':
+        return `run "${action.cmd}" in ${action.target}`;
+      case 'broadcast':
+        return `run "${action.cmd}" in all sessions`;
+      case 'run-group':
+        return `run "${action.cmd}" in group "${action.group}"`;
+      case 'sequential':
+        return `run ${action.cmds.length} commands in ${action.target}`;
+      case 'new':
+        return `create new session${action.name ? ` "${action.name}"` : ''}${action.group ? ` in group "${action.group}"` : ''}`;
+      case 'rename':
+        return `rename "${action.target}" -> "${action.name}"`;
+      case 'close':
+        return action.target.toLowerCase() === 'idle' ? 'close all idle sessions' : `close session "${action.target}"`;
+      case 'close-group':
+        return `close all sessions in group "${action.group}"`;
+      case 'split':
+        return 'split current row';
+      case 'focus':
+        return `focus "${action.target}"`;
+      case 'group':
+        return `move "${action.target}" to group "${action.group}"`;
+      case 'note':
+        return `set note on "${action.target}": ${action.text}`;
+      case 'clear':
+        return `clear terminal output of "${action.target}"`;
+      case 'kill':
+        return `send Ctrl+C to "${action.target}"`;
+      case 'write':
+      case 'paste':
+        return `write to "${action.target}"`;
+      case 'set-agent':
+        return `set "${action.target}" agent to ${action.agentType}`;
+    }
+  }
+
+  isConfirmable(action: WorkspaceAction): boolean {
+    return CONFIRMABLE_TYPES.has(action.type);
+  }
+
+  async dispatch(action: WorkspaceAction, options: DispatchOptions = {}): Promise<WorkspaceActionResult> {
+    const source = options.source ?? 'ui';
+    const entry = this.createLogEntry(source, action);
+    try {
+      const result = this.isConfirmable(action)
+        ? await this.queueConfirmable(action, source)
+        : await this.execute(action, source);
+      entry.result = result;
+      this.finishLogEntry(entry);
+      return result;
+    } catch (error) {
+      const result: WorkspaceActionResult = {
+        ok: false,
+        message: error instanceof Error ? error.message : String(error),
+        action,
+        error: error instanceof Error ? error.message : String(error),
+      };
+      entry.result = result;
+      this.finishLogEntry(entry);
+      return result;
+    }
+  }
+
+  async queueActionBatch(
+    title: string,
+    actions: WorkspaceAction[],
+    options: DispatchOptions = {},
+  ): Promise<string> {
+    const source = options.source ?? 'ui';
+    const preview = actions.map(action => `  ${this.actionDescription(action)}`).join('\n');
+    planExecutor.enqueue({
+      id: this.nextId('plan'),
+      title,
+      preview,
+      actions,
+      execute: async () => this.dispatchMany(actions, source),
+    });
+    return planExecutor.getPlanPreview();
+  }
+
+  findPane(target: string): PaneInfo | undefined {
+    const ports = this.requirePorts();
+    const panes = ports.session.getAllPanes();
+    const normalizedTarget = target.trim().toLowerCase();
+    if (!normalizedTarget) return undefined;
+    const numericTarget = Number.parseInt(normalizedTarget, 10);
+    return panes.find(pane =>
+      pane.name.toLowerCase() === normalizedTarget ||
+      (Number.isFinite(numericTarget) && pane.id === numericTarget)
+    ) || panes.find(pane => pane.name.toLowerCase().includes(normalizedTarget));
+  }
+
+  private async queueConfirmable(action: WorkspaceAction, source: WorkspaceActionSource): Promise<WorkspaceActionResult> {
+    const actions = this.expandConfirmableAction(action);
+    if (actions.length === 0) {
+      return { ok: false, message: `No sessions matched ${this.actionDescription(action)}.`, action };
+    }
+    const title = this.actionDescription(action);
+    const preview = await this.queueActionBatch(title, actions, { source });
+    return { ok: true, message: preview, action };
+  }
+
+  private expandConfirmableAction(action: WorkspaceAction): WorkspaceAction[] {
+    const ports = this.requirePorts();
+    switch (action.type) {
+      case 'broadcast':
+        return ports.session.getAllPanes().map(pane => ({ type: 'run', target: String(pane.id), cmd: action.cmd }));
+      case 'run-group': {
+        const group = action.group.toLowerCase();
+        return ports.session.getAllPanes()
+          .filter(pane => pane.group.toLowerCase() === group)
+          .map(pane => ({ type: 'run', target: String(pane.id), cmd: action.cmd }));
+      }
+      case 'close-group': {
+        const group = action.group.toLowerCase();
+        return ports.session.getAllPanes()
+          .filter(pane => pane.group.toLowerCase() === group)
+          .map(pane => ({ type: 'close', target: String(pane.id) }));
+      }
+      case 'sequential': {
+        const pane = this.findPane(action.target);
+        if (!pane) return [];
+        return action.cmds.map(cmd => ({ type: 'run', target: String(pane.id), cmd }));
+      }
+      default:
+        return [];
+    }
+  }
+
+  private async dispatchMany(actions: WorkspaceAction[], source: WorkspaceActionSource): Promise<WorkspaceActionResult[]> {
+    const results: WorkspaceActionResult[] = [];
+    for (const action of actions) {
+      results.push(await this.dispatch(action, { source }));
+      await delay(300);
+    }
+    return results;
+  }
+
+  private async execute(action: WorkspaceAction, _source: WorkspaceActionSource): Promise<WorkspaceActionResult> {
+    const ports = this.requirePorts();
+
+    switch (action.type) {
+      case 'run': {
+        const pane = this.findPane(action.target);
+        if (!pane) return this.fail(action, `Session "${action.target}" not found.`);
+        await ports.terminal.write(pane.id, `${action.cmd}\r`);
+        ports.viewport.scrollToPane(pane.id);
+        return this.ok(action, `Ran "${action.cmd}" in ${pane.name}.`);
+      }
+
+      case 'new': {
+        const pane = await ports.layout.spawnPane({ newRow: true, group: action.group ?? undefined });
+        if (!pane) return this.fail(action, 'Failed to create session.');
+        if (action.name) await ports.session.renamePane(pane.paneId, action.name, 'manual');
+        if (action.group) await ports.session.setPaneGroup(pane.paneId, action.group);
+        return this.ok(action, `Created new session${action.name ? ` "${action.name}"` : ''}.`);
+      }
+
+      case 'rename': {
+        const pane = this.findPane(action.target);
+        if (!pane) return this.fail(action, `Session "${action.target}" not found.`);
+        await ports.session.renamePane(pane.id, action.name, 'manual');
+        return this.ok(action, `Renamed ${pane.name} -> ${action.name}.`);
+      }
+
+      case 'close': {
+        if (action.target.toLowerCase() === 'idle') {
+          const idle = ports.session.getAllPanes().filter(pane => pane.status === 'idle');
+          for (const pane of idle) await ports.layout.closePane(pane.id);
+          return this.ok(action, `Closed ${idle.length} idle session(s).`);
+        }
+        const pane = this.findPane(action.target);
+        if (!pane) return this.fail(action, `Session "${action.target}" not found.`);
+        await ports.layout.closePane(pane.id);
+        return this.ok(action, `Closed ${pane.name}.`);
+      }
+
+      case 'split':
+        await ports.layout.splitCurrentRow();
+        return this.ok(action, 'Split current row.');
+
+      case 'focus': {
+        const pane = this.findPane(action.target);
+        if (!pane) return this.fail(action, `Session "${action.target}" not found.`);
+        await ports.session.setActivePane(pane.id);
+        ports.viewport.scrollToPane(pane.id);
+        return this.ok(action, `Focused ${pane.name}.`);
+      }
+
+      case 'group': {
+        const pane = this.findPane(action.target);
+        if (!pane) return this.fail(action, `Session "${action.target}" not found.`);
+        await ports.session.setPaneGroup(pane.id, action.group);
+        return this.ok(action, `Moved ${pane.name} to group "${action.group}".`);
+      }
+
+      case 'note': {
+        const pane = this.findPane(action.target);
+        if (!pane) return this.fail(action, `Session "${action.target}" not found.`);
+        await ports.session.setPaneNote(pane.id, action.text);
+        return this.ok(action, `Set note on ${pane.name}.`);
+      }
+
+      case 'clear': {
+        const pane = this.findPane(action.target);
+        if (!pane) return this.fail(action, `Session "${action.target}" not found.`);
+        await ports.terminal.write(pane.id, 'clear\r');
+        return this.ok(action, `Cleared ${pane.name}.`);
+      }
+
+      case 'kill': {
+        const pane = this.findPane(action.target);
+        if (!pane) return this.fail(action, `Session "${action.target}" not found.`);
+        await ports.terminal.write(pane.id, '\x03');
+        return this.ok(action, `Sent Ctrl+C to ${pane.name}.`);
+      }
+
+      case 'write':
+      case 'paste': {
+        const pane = this.findPane(action.target);
+        if (!pane) return this.fail(action, `Session "${action.target}" not found.`);
+        await ports.terminal.write(pane.id, action.data);
+        return this.ok(action, `Wrote to ${pane.name}.`);
+      }
+
+      case 'set-agent': {
+        const pane = this.findPane(action.target);
+        if (!pane) return this.fail(action, `Session "${action.target}" not found.`);
+        await ports.session.setPaneAgent(pane.id, action.agentType);
+        return this.ok(action, `Set ${pane.name} agent to "${action.agentType}".`);
+      }
+
+      case 'broadcast':
+      case 'run-group':
+      case 'close-group':
+      case 'sequential':
+        return this.queueConfirmable(action, _source);
+    }
+  }
+
+  private requirePorts(): WorkspaceActionPorts {
+    if (!this.ports) throw new Error('Workspace actions are not configured.');
+    return this.ports;
+  }
+
+  private ok(action: WorkspaceAction, message: string): WorkspaceActionResult {
+    return { ok: true, message, action };
+  }
+
+  private fail(action: WorkspaceAction, message: string): WorkspaceActionResult {
+    return { ok: false, message, action, error: message };
+  }
+
+  private createLogEntry(source: WorkspaceActionSource, action: WorkspaceAction): ActionLogEntry {
+    return {
+      id: this.nextId('action'),
+      timestamp: Date.now(),
+      source,
+      action,
+    };
+  }
+
+  private finishLogEntry(entry: ActionLogEntry) {
+    if (entry.action.type !== 'write' && entry.action.type !== 'paste') {
+      this.logEntries.push(entry);
+      if (this.logEntries.length > ACTION_LOG_LIMIT) this.logEntries.shift();
+      this.ports?.log?.log(entry);
+    }
+  }
+
+  private nextId(prefix: string): string {
+    return `${prefix}-${this.nextLogId++}`;
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export function actionDescription(action: WorkspaceAction): string {
+  return workspaceActions.actionDescription(action);
+}
+
+export const workspaceActions = new WorkspaceActions();

--- a/src/workspace/WorkspaceActions.ts
+++ b/src/workspace/WorkspaceActions.ts
@@ -1,8 +1,35 @@
 import { planExecutor } from '../ai/plan-executor';
+import { getPaneContext } from './WorkspaceState';
+import { waitForCommandComplete } from './waitForCommand';
 import type { PaneInfo, AgentType, SessionStatus } from '../session/types';
+
+/** A single action within a pipeline step. */
+export interface PipelineStepAction {
+  target: string;
+  cmd: string;
+  timeout_ms?: number;
+}
+
+/**
+ * One step in a pipeline. All actions within a step run in parallel by default
+ * (parallel: false runs them sequentially). The optional condition gates entry:
+ *
+ *   'always'        – always run this step (default)
+ *   'prev-success'  – only run if every action in the previous step exited 0
+ *   'prev-fail'     – only run if any action in the previous step exited non-0
+ */
+export interface PipelineStep {
+  label?: string;
+  parallel?: boolean;
+  condition?: 'always' | 'prev-success' | 'prev-fail';
+  actions: PipelineStepAction[];
+}
 
 export type WorkspaceAction =
   | { type: 'run'; target: string; cmd: string }
+  | { type: 'run-await'; target: string; cmd: string; timeout_ms?: number }
+  | { type: 'read'; target: string }
+  | { type: 'pipeline'; label?: string; steps: PipelineStep[] }
   | { type: 'broadcast'; cmd: string }
   | { type: 'run-group'; group: string; cmd: string }
   | { type: 'sequential'; target: string; cmds: string[] }
@@ -112,6 +139,21 @@ class WorkspaceActions {
     switch (action.type) {
       case 'run':
         return `run "${action.cmd}" in ${action.target}`;
+      case 'run-await':
+        return `run "${action.cmd}" in ${action.target} (await completion)`;
+      case 'read':
+        return `read output from "${action.target}"`;
+      case 'pipeline': {
+        const stepList = action.steps
+          .map((s, i) => {
+            const acts = s.actions.map(a => `${a.target}: ${a.cmd}`).join(', ');
+            const cond = s.condition && s.condition !== 'always' ? ` [if ${s.condition}]` : '';
+            const par = s.parallel === false ? ' [sequential]' : '';
+            return `  ${i + 1}. ${s.label ? `${s.label}: ` : ''}${acts}${cond}${par}`;
+          })
+          .join('\n');
+        return `${action.label ?? 'Pipeline'} (${action.steps.length} steps):\n${stepList}`;
+      }
       case 'broadcast':
         return `run "${action.cmd}" in all sessions`;
       case 'run-group':
@@ -258,6 +300,76 @@ class WorkspaceActions {
         await ports.terminal.write(pane.id, `${action.cmd}\r`);
         ports.viewport.scrollToPane(pane.id);
         return this.ok(action, `Ran "${action.cmd}" in ${pane.name}.`);
+      }
+
+      case 'run-await': {
+        const pane = this.findPane(action.target);
+        if (!pane) return this.fail(action, `Session "${action.target}" not found.`);
+        await ports.terminal.write(pane.id, `${action.cmd}\r`);
+        ports.viewport.scrollToPane(pane.id);
+        try {
+          const result = await waitForCommandComplete(pane.id, action.timeout_ms ?? 60_000);
+          const ok = result.exitCode === 0;
+          return {
+            ok,
+            message: `${pane.name}: exit ${result.exitCode}`,
+            action,
+            ...(ok ? {} : { error: `Command exited with code ${result.exitCode}` }),
+          };
+        } catch (err) {
+          return this.fail(action, err instanceof Error ? err.message : 'Timeout');
+        }
+      }
+
+      case 'read': {
+        const pane = this.findPane(action.target);
+        if (!pane) return this.fail(action, `Session "${action.target}" not found.`);
+        const ctx = await getPaneContext(pane.id);
+        if (!ctx) return this.fail(action, `Could not read context for "${pane.name}".`);
+        const lines = ctx.recent_output.join('\n');
+        const exitInfo = pane.last_exit_code != null ? `\nExit code: ${pane.last_exit_code}` : '';
+        const lastCmd = pane.last_command ? `\nLast command: ${pane.last_command}` : '';
+        return this.ok(action, `${pane.name}:${lastCmd}${exitInfo}\n${lines}`);
+      }
+
+      case 'pipeline': {
+        const stepSummaries: string[] = [];
+        let prevResults: WorkspaceActionResult[] = [];
+
+        for (const step of action.steps) {
+          if (prevResults.length > 0) {
+            if (step.condition === 'prev-success' && prevResults.some(r => !r.ok)) {
+              stepSummaries.push(`Stopped before "${step.label ?? 'next step'}" — previous step failed`);
+              break;
+            }
+            if (step.condition === 'prev-fail' && prevResults.every(r => r.ok)) {
+              stepSummaries.push(`Skipped "${step.label ?? 'next step'}" — previous step succeeded`);
+              break;
+            }
+          }
+
+          const stepActions = step.actions.map(a => ({
+            type: 'run-await' as const,
+            target: a.target,
+            cmd: a.cmd,
+            timeout_ms: a.timeout_ms,
+          }));
+
+          const stepResults: WorkspaceActionResult[] = [];
+          if (step.parallel !== false) {
+            stepResults.push(...await Promise.all(stepActions.map(a => this.execute(a, _source))));
+          } else {
+            for (const a of stepActions) {
+              stepResults.push(await this.execute(a, _source));
+            }
+          }
+          prevResults = stepResults;
+
+          const stepMsg = stepResults.map(r => r.message).join(', ');
+          stepSummaries.push(step.label ? `${step.label}: ${stepMsg}` : stepMsg);
+        }
+
+        return this.ok(action, stepSummaries.join('\n') || 'Pipeline complete.');
       }
 
       case 'new': {

--- a/src/workspace/WorkspaceState.ts
+++ b/src/workspace/WorkspaceState.ts
@@ -1,0 +1,86 @@
+import { sessionManager } from '../session/SessionManager';
+import { transport } from '../transport';
+import type { PaneInfo } from '../session/types';
+
+// ── Per-pane AI context API ───────────────────────────────────────────────────
+
+export interface PaneContext {
+  info: PaneInfo;
+  /** Recent PTY output lines (ANSI stripped, up to 50 lines). */
+  recent_output: string[];
+}
+
+/** Fetch structured context for a single pane, including recent output. */
+export async function getPaneContext(paneId: number): Promise<PaneContext | null> {
+  return transport.send<PaneContext | null>('get_pane_context', { paneId });
+}
+
+export interface WorkspaceRowSnapshot {
+  note: string;
+  panes: { id: number }[];
+}
+
+export interface WorkspaceLayoutReader {
+  getRowsWithNotes(): WorkspaceRowSnapshot[];
+}
+
+export interface SerializedWorkspaceState {
+  panes: PaneInfo[];
+  active_pane_id: number | null;
+  rows: Array<{
+    index: number;
+    note: string;
+    pane_ids: number[];
+  }>;
+}
+
+let layoutReader: WorkspaceLayoutReader | null = null;
+
+export function setWorkspaceLayoutReader(reader: WorkspaceLayoutReader) {
+  layoutReader = reader;
+}
+
+export function serializeWorkspaceState(): SerializedWorkspaceState {
+  const panes = sessionManager.getAllPanes();
+  const rows = (layoutReader?.getRowsWithNotes() ?? sessionManager.getPanesByRow().map(row => ({
+    note: '',
+    panes: row.map(p => ({ id: p.id })),
+  }))).map((row, index) => ({
+    index,
+    note: row.note,
+    pane_ids: row.panes.map(p => p.id),
+  }));
+
+  return {
+    panes,
+    active_pane_id: sessionManager.getActivePaneId(),
+    rows,
+  };
+}
+
+export function formatWorkspaceContext(state: SerializedWorkspaceState = serializeWorkspaceState()): string {
+  const lines = state.panes.map(pane => {
+    const active = pane.id === state.active_pane_id ? ' <- active' : '';
+    const agent = pane.agent_type !== 'none' ? ` (${pane.agent_type})` : '';
+    const source = pane.name_source === 'auto' ? 'auto-name' : 'manual-name';
+    const altScreen = pane.alternate_screen ? ' [alt-screen]' : '';
+    const lastCmd = pane.last_command ? ` last: ${pane.last_command}` : '';
+    const exitCode = pane.last_exit_code != null
+      ? ` exit:${pane.last_exit_code}`
+      : '';
+    return `  ${pane.id}. ${pane.name} [${pane.group}] ${pane.status}${agent} ${source} cwd: ${pane.cwd}${altScreen}${lastCmd}${exitCode}${active}`;
+  });
+
+  if (lines.length === 0) return '  (no sessions)';
+
+  const rowLines = state.rows.length > 0
+    ? state.rows.map(row => {
+        const note = row.note.trim() ? ` note: ${row.note.trim()}` : '';
+        return `  row ${row.index}: ${row.pane_ids.join(', ')}${note}`;
+      })
+    : [];
+
+  return rowLines.length > 0
+    ? `${lines.join('\n')}\n\nRows:\n${rowLines.join('\n')}`
+    : lines.join('\n');
+}

--- a/src/workspace/WorkspaceState.ts
+++ b/src/workspace/WorkspaceState.ts
@@ -60,15 +60,19 @@ export function serializeWorkspaceState(): SerializedWorkspaceState {
 
 export function formatWorkspaceContext(state: SerializedWorkspaceState = serializeWorkspaceState()): string {
   const lines = state.panes.map(pane => {
-    const active = pane.id === state.active_pane_id ? ' <- active' : '';
+    const active = pane.id === state.active_pane_id ? ' <- ACTIVE' : '';
     const agent = pane.agent_type !== 'none' ? ` (${pane.agent_type})` : '';
     const source = pane.name_source === 'auto' ? 'auto-name' : 'manual-name';
-    const altScreen = pane.alternate_screen ? ' [alt-screen]' : '';
-    const lastCmd = pane.last_command ? ` last: ${pane.last_command}` : '';
+    // Alt-screen: TUI app is running — shell commands won't work until it exits
+    const altScreen = pane.alternate_screen ? ' [TUI:no-shell]' : '';
+    const statusLabel = pane.status === 'running' ? ' [RUNNING]' : '';
+    const lastCmd = pane.last_command ? ` last:"${pane.last_command}"` : '';
     const exitCode = pane.last_exit_code != null
-      ? ` exit:${pane.last_exit_code}`
+      ? pane.last_exit_code !== 0
+        ? ` exit:${pane.last_exit_code}⚠`
+        : ` exit:0`
       : '';
-    return `  ${pane.id}. ${pane.name} [${pane.group}] ${pane.status}${agent} ${source} cwd: ${pane.cwd}${altScreen}${lastCmd}${exitCode}${active}`;
+    return `  ${pane.id}. ${pane.name} [${pane.group}]${statusLabel} ${source} cwd:${pane.cwd}${agent}${altScreen}${lastCmd}${exitCode}${active}`;
   });
 
   if (lines.length === 0) return '  (no sessions)';

--- a/src/workspace/waitForCommand.ts
+++ b/src/workspace/waitForCommand.ts
@@ -1,0 +1,40 @@
+import { transport } from '../transport';
+
+interface CommandCompletePayload {
+  pane_id: number;
+  exit_code: number;
+}
+
+/**
+ * Waits for the shell in `paneId` to emit an OSC 133;D sequence, which the
+ * Rust backend translates into a `pane:command_complete` event.
+ *
+ * Limitation: if another command completes in the same pane before the one you
+ * just wrote (e.g. a background job), this promise resolves early. Callers that
+ * need stricter sequencing should snapshot `PaneInfo.last_exit_code` before
+ * writing and compare after resolving.
+ */
+export function waitForCommandComplete(
+  paneId: number,
+  timeoutMs = 60_000,
+): Promise<{ exitCode: number }> {
+  return new Promise((resolve, reject) => {
+    let unlisten: (() => void) | null = null;
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      unlisten?.();
+      reject(new Error(`Timeout waiting for pane ${paneId} to complete (${timeoutMs}ms)`));
+    }, timeoutMs);
+
+    transport.listen<CommandCompletePayload>('pane:command_complete', (payload) => {
+      if (payload.pane_id !== paneId || settled) return;
+      settled = true;
+      clearTimeout(timer);
+      unlisten?.();
+      resolve({ exitCode: payload.exit_code });
+    }).then(fn => { unlisten = fn; });
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    // Prefer .ts over .js so vitest loads source files, not compiled artifacts.
+    extensions: ['.ts', '.tsx', '.mts', '.js', '.jsx', '.mjs', '.json'],
+    alias: {
+      // Stub out Tauri APIs so tests run in Node without a WebView.
+      '@tauri-apps/api/core': path.resolve(__dirname, 'src/__mocks__/tauri-core.ts'),
+      '@tauri-apps/api/event': path.resolve(__dirname, 'src/__mocks__/tauri-event.ts'),
+    },
+  },
+  test: {
+    environment: 'node',
+    include: ['src/__tests__/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

- **Pipeline action type**: new `pipeline` action in `WorkspaceActions` lets the workspace AI compose multi-step, conditionally-gated command pipelines across panes — each step can run actions in parallel or sequentially, and conditions (`always` / `prev-success` / `prev-fail`) gate entry into the next step
- **`run-await` and `read` actions**: `run-await` writes a command to a pane and waits for OSC 133;D shell integration signal before continuing; `read` captures pane output for use in subsequent pipeline steps
- **`waitForCommandComplete` utility**: `src/workspace/waitForCommand.ts` implements the promise-based wait on `pane:command_complete` IPC events with configurable timeout
- **Test scaffolding**: vitest config + `@tauri-apps/api` mocks + unit tests for `WorkspaceActions`, `WorkspaceState`, `ai-handler`, and `waitForCommand`
- **Version bump**: 0.1.7 → 0.1.8 across `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`

## Test plan

- [ ] Run `npm test` (vitest) — all four test suites should pass
- [ ] Smoke-test pipeline dispatch via `:` command bar: `run echo hello in pane1 then run echo world in pane2`
- [ ] Verify `run-await` blocks until command finishes before continuing to next pipeline step
- [ ] Confirm version shows `0.1.8` in app title bar / About

🤖 Generated with [Claude Code](https://claude.com/claude-code)