### PR TITLE
fix: restore insert input routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fluxtty",
-  "version": "0.1.7",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fluxtty",
-      "version": "0.1.7",
+      "version": "0.1.9",
       "dependencies": {
         "@tauri-apps/api": "^2.5.0",
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluxtty",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "description": "Multi-session developer workspace terminal",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "fluxtty"
-version = "0.1.7"
+version = "0.1.9"
 dependencies = [
  "crossbeam-channel",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluxtty"
-version = "0.1.8"
+version = "0.1.9"
 description = "Multi-session developer workspace terminal"
 authors = ["fluxtty"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "fluxtty",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "identifier": "dev.fluxtty.app",
   "build": {
     "devUrl": "http://localhost:1420",

--- a/src/input/InputBar.ts
+++ b/src/input/InputBar.ts
@@ -24,9 +24,15 @@ function longestCommonPrefix(strs: string[]): string {
 }
 
 function isEditableElement(el: Element | null): boolean {
+  if (isXtermHelperInput(el)) return false;
   return el instanceof HTMLTextAreaElement
     || el instanceof HTMLInputElement
     || (el instanceof HTMLElement && el.isContentEditable);
+}
+
+function isXtermHelperInput(el: Element | null): boolean {
+  if (!(el instanceof HTMLTextAreaElement)) return false;
+  return el.classList.contains('xterm-helper-textarea');
 }
 
 function splitShellInputForCompletion(input: string): { prefix: string; currentWord: string } {
@@ -904,6 +910,9 @@ export class InputBar {
       }
       case 'insert': {
         this.inputEl.readOnly = false;
+        if (configContext.get().input.live_typing && !this.liveTypingMirrorSynced) {
+          this.resetLiveTypingMirror();
+        }
         this.refreshInsertPrompt();
         this.inputEl.focus();
         break;


### PR DESCRIPTION
## Summary
- Route Insert-mode keys away from xterm's internal helper textarea and back through the input bar
- Reset stale live-typing mirror state when re-entering Insert mode
- Bump release version to 0.1.9

## Verification
- npm test
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml