### PR TITLE
Release/v0.1.12

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -209,6 +209,7 @@ pub struct WaterfallConfig {
     pub pane_min_width: u32,
     pub show_note_button: bool,
     pub inactive_pane_scrim_strength: u32,
+    pub min_row_lines: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -427,6 +428,7 @@ impl Default for WaterfallConfig {
             pane_min_width: 150,
             show_note_button: true,
             inactive_pane_scrim_strength: 22,
+            min_row_lines: 30,
         }
     }
 }

--- a/src/config/ConfigContext.ts
+++ b/src/config/ConfigContext.ts
@@ -62,7 +62,7 @@ export interface AppConfig {
     always_confirm_multi_step: boolean;
     agent_relay_auto_submit?: boolean;
   };
-  waterfall: { row_height_mode: string; fixed_row_height: number; scroll_snap: boolean; new_pane_focus: boolean; note_width: number; pane_min_width: number; show_note_button: boolean; inactive_pane_scrim_strength: number };
+  waterfall: { row_height_mode: string; fixed_row_height: number; scroll_snap: boolean; new_pane_focus: boolean; note_width: number; pane_min_width: number; show_note_button: boolean; inactive_pane_scrim_strength: number; min_row_lines: number };
   persistence: { restore_workspace_on_launch: boolean; scrollback_lines: number; save_scrollback_on_exit: boolean };
 }
 

--- a/src/settings/SettingsPanel.ts
+++ b/src/settings/SettingsPanel.ts
@@ -858,6 +858,7 @@ const SECTIONS: Section[] = [
         label: 'Layout (Waterfall)',
         fields: [
           { path: 'waterfall.row_height_mode',  label: 'Row height mode',  type: 'select', opts: ['viewport','fixed'] },
+          { path: 'waterfall.min_row_lines',    label: 'Min row lines',    type: 'number', min: 5,  max: 200, desc: 'viewport mode only — min lines per row before waterfall scrolling kicks in' },
           { path: 'waterfall.fixed_row_height', label: 'Fixed row height', type: 'number', min: 10, max: 200, desc: 'rows (used when mode = fixed)' },
           { path: 'waterfall.scroll_snap',      label: 'Scroll snap',      type: 'checkbox' },
           { path: 'waterfall.new_pane_focus',   label: 'Focus new pane',   type: 'checkbox' },

--- a/src/waterfall/WaterfallArea.ts
+++ b/src/waterfall/WaterfallArea.ts
@@ -191,10 +191,10 @@ export class WaterfallArea {
       // Phase 1: rows fit on screen, divide height evenly.
       // Phase 2: rows stop shrinking once they hit the minimum useful height;
       // the workspace remains scrollable in a classic waterfall layout.
-      const MIN_LINES = 18;
+      const minLines = cfg.waterfall.min_row_lines ?? 30;
       const paneChromeH = PANE_HEADER_HEIGHT + ROW_BORDER_Y + TERM_PADDING_Y;
       const lineH = cfg.font.size * 1.2;
-      const threshold = paneChromeH + Math.ceil(MIN_LINES * lineH);
+      const threshold = paneChromeH + Math.ceil(minLines * lineH);
       const overhead = cfg.window.padding.y * 2 + (rowCount > 1 ? rowGap * (rowCount - 1) : 0);
       const idealOuterHeight = rowCount > 0 ? Math.floor((containerH - overhead) / rowCount) : containerH;
       rowHeight = idealOuterHeight >= threshold ? idealOuterHeight : threshold;


### PR DESCRIPTION
## Changes

- Add configurable `waterfall.min_row_lines` (default **30**) — replaces the hardcoded 18-line minimum row height in viewport mode
- Exposed in Settings → Layout → **Min row lines** (range 5–200)
- `fixed` row height mode is unaffected

## How to configure

```yaml
waterfall:
  min_row_lines: 30
```

## Test plan

- [ ] Open Settings (Ctrl+,) → Layout → verify "Min row lines" field appears with value 30
- [ ] Change value → row heights recalc immediately (hot-reload)
- [ ] Set `row_height_mode: fixed` → min_row_lines has no effect
- [ ] Verify on 27" 2560×1440: with default 30 lines, waterfall scroll kicks in at row 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)